### PR TITLE
Implement BookTransformer for Amazon affiliate book cards

### DIFF
--- a/cli/io.ts
+++ b/cli/io.ts
@@ -7,7 +7,12 @@ import fm, { type FrontMatterResult } from "front-matter";
 import { remark } from "remark";
 
 import { compile } from "@mdx-js/mdx";
-import { REHYPE_PLUGINS, REMARK_PLUGINS } from "md-plugins";
+import {
+  BookTransformer,
+  REHYPE_PLUGINS,
+  REMARK_PLUGINS,
+  remarkDirectiveEmbedGenerator,
+} from "md-plugins";
 
 import {
   type Dump,
@@ -97,10 +102,19 @@ export async function dumpPost(
                 ],
               ]
             : []),
-        ].concat(
-          // @ts-ignore
-          REMARK_PLUGINS,
-        ),
+        ]
+          .concat(
+            // @ts-ignore
+            REMARK_PLUGINS,
+          )
+          .concat([
+            remarkDirectiveEmbedGenerator([
+              new BookTransformer({
+                associateTagJp: process.env.AMAZON_ASSOCIATE_TAG_JP,
+                associateTagUs: process.env.AMAZON_ASSOCIATE_TAG_US,
+              }),
+            ]),
+          ]),
         rehypePlugins: [
           REHYPE_PLUGINS.rehypeKatex,
           [

--- a/cli/io.ts
+++ b/cli/io.ts
@@ -112,6 +112,7 @@ export async function dumpPost(
               new BookTransformer({
                 associateTagJp: process.env.AMAZON_ASSOCIATE_TAG_JP,
                 associateTagUs: process.env.AMAZON_ASSOCIATE_TAG_US,
+                defaultRegion: post.meta.lang === "en" ? "us" : "jp",
               }),
             ]),
           ]),

--- a/packages/md-plugins/index.ts
+++ b/packages/md-plugins/index.ts
@@ -19,7 +19,6 @@ import remarkDirectiveEmbedGenerator, {
   GithubMetaTransformer,
   GithubTransformer,
 } from "./remark-plugins/embed";
-import { BookTransformer } from "./remark-plugins/embed/book";
 import { DoiTransformer } from "./remark-plugins/embed/doi";
 import { YouTubeTransformer } from "./remark-plugins/embed/youtube";
 
@@ -37,7 +36,6 @@ export const REMARK_PLUGINS = [
     new GithubMetaTransformer(),
     new YouTubeTransformer(),
     new DoiTransformer(),
-    new BookTransformer(),
   ]),
   remarkMdx,
 ];
@@ -60,3 +58,8 @@ export {
 } from "./fetch";
 export { cachedFetch } from "./cachedFetch";
 export { getCacheKey, cacheGet, cacheSet, getDefaultCacheDir } from "./cache";
+export { default as remarkDirectiveEmbedGenerator } from "./remark-plugins/embed";
+export {
+  BookTransformer,
+  type BookTransformerOptions,
+} from "./remark-plugins/embed/book";

--- a/packages/md-plugins/index.ts
+++ b/packages/md-plugins/index.ts
@@ -19,6 +19,7 @@ import remarkDirectiveEmbedGenerator, {
   GithubMetaTransformer,
   GithubTransformer,
 } from "./remark-plugins/embed";
+import { BookTransformer } from "./remark-plugins/embed/book";
 import { DoiTransformer } from "./remark-plugins/embed/doi";
 import { YouTubeTransformer } from "./remark-plugins/embed/youtube";
 
@@ -36,6 +37,7 @@ export const REMARK_PLUGINS = [
     new GithubMetaTransformer(),
     new YouTubeTransformer(),
     new DoiTransformer(),
+    new BookTransformer(),
   ]),
   remarkMdx,
 ];

--- a/packages/md-plugins/remark-plugins/embed/book.test.ts
+++ b/packages/md-plugins/remark-plugins/embed/book.test.ts
@@ -1,6 +1,8 @@
+import type { Paragraph } from "mdast";
 import type { Directives } from "mdast-util-directive";
-import { describe, expect, it, vi } from "vitest";
-import { BookTransformer, getBookInfo } from "./book";
+import type { Parent } from "unist";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { BookTransformer, buildAmazonUrl, getBookInfo } from "./book";
 
 vi.mock("../../cache", () => ({
   getCacheKey: vi.fn().mockReturnValue("test-key"),
@@ -33,61 +35,230 @@ describe("getBookInfo", () => {
     expect(info.description).toBe("A test book description");
     expect(info.authors).toEqual(["Author One", "Author Two"]);
     expect(info.thumbnail).toBe("https://example.com/thumb.jpg");
-    expect(info.isbn10).toBe("0123456789");
+    expect(info.isbn).toBe("0123456789");
+  });
+
+  it("handles ISBN-13", async () => {
+    const info = await getBookInfo("9780123456789");
+    expect(info.isbn).toBe("9780123456789");
+  });
+});
+
+describe("buildAmazonUrl", () => {
+  afterEach(() => {
+    delete process.env.AMAZON_ASSOCIATE_TAG_JP;
+    delete process.env.AMAZON_ASSOCIATE_TAG_US;
+  });
+
+  it("generates Amazon.co.jp URL for jp region", () => {
+    const url = buildAmazonUrl("0123456789", "jp");
+    expect(url).toBe("https://www.amazon.co.jp/dp/0123456789");
+  });
+
+  it("generates Amazon.com URL for us region", () => {
+    const url = buildAmazonUrl("0123456789", "us");
+    expect(url).toBe("https://www.amazon.com/dp/0123456789");
+  });
+
+  it("includes JP associate tag when set", () => {
+    process.env.AMAZON_ASSOCIATE_TAG_JP = "mytag-22";
+    const url = buildAmazonUrl("0123456789", "jp");
+    expect(url).toBe("https://www.amazon.co.jp/dp/0123456789?tag=mytag-22");
+  });
+
+  it("includes US associate tag when set", () => {
+    process.env.AMAZON_ASSOCIATE_TAG_US = "mytag-20";
+    const url = buildAmazonUrl("0123456789", "us");
+    expect(url).toBe("https://www.amazon.com/dp/0123456789?tag=mytag-20");
   });
 });
 
 describe("BookTransformer", () => {
-  const transformer = new BookTransformer();
+  describe("shouldTransform", () => {
+    const transformer = new BookTransformer();
 
-  it("accepts valid isbn leafDirective with 10-digit ISBN", () => {
-    const node = {
-      type: "leafDirective",
-      name: "isbn",
-      children: [{ type: "text", value: "0123456789" }],
-    } as unknown as Directives;
+    it("accepts valid isbn leafDirective with 10-digit ISBN", () => {
+      const node = {
+        type: "leafDirective",
+        name: "isbn",
+        children: [{ type: "text", value: "0123456789" }],
+      } as unknown as Directives;
 
-    expect(transformer.shouldTransform(node)).toBe(true);
-    expect(transformer.isbn10).toBe("0123456789");
+      expect(transformer.shouldTransform(node)).toBe(true);
+      expect(transformer.isbn).toBe("0123456789");
+    });
+
+    it("accepts 13-digit ISBN", () => {
+      const node = {
+        type: "leafDirective",
+        name: "isbn",
+        children: [{ type: "text", value: "9780123456789" }],
+      } as unknown as Directives;
+
+      expect(transformer.shouldTransform(node)).toBe(true);
+      expect(transformer.isbn).toBe("9780123456789");
+    });
+
+    it("rejects non-leafDirective", () => {
+      const node = {
+        type: "textDirective",
+        name: "isbn",
+        children: [{ type: "text", value: "0123456789" }],
+      } as unknown as Directives;
+
+      expect(transformer.shouldTransform(node)).toBe(false);
+    });
+
+    it("rejects non-isbn directive", () => {
+      const node = {
+        type: "leafDirective",
+        name: "doi",
+        children: [{ type: "text", value: "0123456789" }],
+      } as unknown as Directives;
+
+      expect(transformer.shouldTransform(node)).toBe(false);
+    });
+
+    it("rejects ISBN with wrong length", () => {
+      const node = {
+        type: "leafDirective",
+        name: "isbn",
+        children: [{ type: "text", value: "12345" }],
+      } as unknown as Directives;
+
+      expect(transformer.shouldTransform(node)).toBe(false);
+    });
+
+    it("rejects ISBN with 11 digits", () => {
+      const node = {
+        type: "leafDirective",
+        name: "isbn",
+        children: [{ type: "text", value: "01234567890" }],
+      } as unknown as Directives;
+
+      expect(transformer.shouldTransform(node)).toBe(false);
+    });
   });
 
-  it("rejects non-leafDirective", () => {
-    const node = {
-      type: "textDirective",
-      name: "isbn",
-      children: [{ type: "text", value: "0123456789" }],
-    } as unknown as Directives;
+  describe("transform", () => {
+    afterEach(() => {
+      delete process.env.AMAZON_ASSOCIATE_TAG_JP;
+      delete process.env.AMAZON_ASSOCIATE_TAG_US;
+    });
 
-    expect(transformer.shouldTransform(node)).toBe(false);
-  });
+    it("generates a book card with Amazon.co.jp link by default", async () => {
+      const transformer = new BookTransformer();
+      const node = {
+        type: "leafDirective",
+        name: "isbn",
+        children: [{ type: "text", value: "0123456789" }],
+      } as unknown as Directives;
 
-  it("rejects non-isbn directive", () => {
-    const node = {
-      type: "leafDirective",
-      name: "doi",
-      children: [{ type: "text", value: "0123456789" }],
-    } as unknown as Directives;
+      const parent: Parent = {
+        type: "root",
+        children: [node],
+      };
 
-    expect(transformer.shouldTransform(node)).toBe(false);
-  });
+      await transformer.transform(node, 0, parent);
 
-  it("rejects ISBN with wrong length", () => {
-    const node = {
-      type: "leafDirective",
-      name: "isbn",
-      children: [{ type: "text", value: "12345" }],
-    } as unknown as Directives;
+      const card = parent.children[0] as Paragraph;
+      expect(card.data).toEqual({
+        hName: "div",
+        hProperties: { className: "book-card" },
+      });
 
-    expect(transformer.shouldTransform(node)).toBe(false);
-  });
+      // Check thumbnail link points to Amazon.co.jp
+      const thumbnailLink = card.children[0] as { type: string; url: string };
+      expect(thumbnailLink.url).toBe(
+        "https://www.amazon.co.jp/dp/0123456789",
+      );
+      expect(thumbnailLink.data).toEqual({
+        hProperties: { target: "_blank", rel: "noopener sponsored" },
+      });
+    });
 
-  it("rejects ISBN with 11 digits", () => {
-    const node = {
-      type: "leafDirective",
-      name: "isbn",
-      children: [{ type: "text", value: "01234567890" }],
-    } as unknown as Directives;
+    it("generates Amazon.com link with {#us} attribute", async () => {
+      const transformer = new BookTransformer();
+      const node = {
+        type: "leafDirective",
+        name: "isbn",
+        attributes: { id: "us" },
+        children: [{ type: "text", value: "0123456789" }],
+      } as unknown as Directives;
 
-    expect(transformer.shouldTransform(node)).toBe(false);
+      const parent: Parent = {
+        type: "root",
+        children: [node],
+      };
+
+      await transformer.transform(node, 0, parent);
+
+      const card = parent.children[0] as Paragraph;
+      const thumbnailLink = card.children[0] as { type: string; url: string };
+      expect(thumbnailLink.url).toBe("https://www.amazon.com/dp/0123456789");
+
+      // Check button text is English
+      const infoNode = card.children[1] as Paragraph;
+      const buttonNode = infoNode.children[2] as Paragraph;
+      expect(buttonNode.children[0]).toEqual({
+        type: "text",
+        value: "View on Amazon",
+      });
+    });
+
+    it("includes associate tag in URL when env var is set", async () => {
+      process.env.AMAZON_ASSOCIATE_TAG_JP = "test-22";
+      const transformer = new BookTransformer();
+      const node = {
+        type: "leafDirective",
+        name: "isbn",
+        children: [{ type: "text", value: "0123456789" }],
+      } as unknown as Directives;
+
+      const parent: Parent = {
+        type: "root",
+        children: [node],
+      };
+
+      await transformer.transform(node, 0, parent);
+
+      const card = parent.children[0] as Paragraph;
+      const thumbnailLink = card.children[0] as { type: string; url: string };
+      expect(thumbnailLink.url).toBe(
+        "https://www.amazon.co.jp/dp/0123456789?tag=test-22",
+      );
+    });
+
+    it("renders book title and authors from API response", async () => {
+      const transformer = new BookTransformer();
+      const node = {
+        type: "leafDirective",
+        name: "isbn",
+        children: [{ type: "text", value: "0123456789" }],
+      } as unknown as Directives;
+
+      const parent: Parent = {
+        type: "root",
+        children: [node],
+      };
+
+      await transformer.transform(node, 0, parent);
+
+      const card = parent.children[0] as Paragraph;
+      const infoNode = card.children[1] as Paragraph;
+
+      // Title link
+      const titleLink = infoNode.children[0] as {
+        children: { children: { value: string }[] }[];
+      };
+      expect(titleLink.children[0].children[0].value).toBe("Test Book");
+
+      // Authors
+      const authorsNode = infoNode.children[1] as Paragraph;
+      expect(authorsNode.children[0]).toEqual({
+        type: "text",
+        value: "Author One, Author Two",
+      });
+    });
   });
 });

--- a/packages/md-plugins/remark-plugins/embed/book.test.ts
+++ b/packages/md-plugins/remark-plugins/embed/book.test.ts
@@ -46,8 +46,8 @@ describe("getBookInfo", () => {
 
 describe("buildAmazonUrl", () => {
   afterEach(() => {
-    delete process.env.AMAZON_ASSOCIATE_TAG_JP;
-    delete process.env.AMAZON_ASSOCIATE_TAG_US;
+    process.env.AMAZON_ASSOCIATE_TAG_JP = "";
+    process.env.AMAZON_ASSOCIATE_TAG_US = "";
   });
 
   it("generates Amazon.co.jp URL for jp region", () => {
@@ -142,8 +142,8 @@ describe("BookTransformer", () => {
 
   describe("transform", () => {
     afterEach(() => {
-      delete process.env.AMAZON_ASSOCIATE_TAG_JP;
-      delete process.env.AMAZON_ASSOCIATE_TAG_US;
+      process.env.AMAZON_ASSOCIATE_TAG_JP = "";
+      process.env.AMAZON_ASSOCIATE_TAG_US = "";
     });
 
     it("generates a book card with Amazon.co.jp link by default", async () => {
@@ -169,9 +169,7 @@ describe("BookTransformer", () => {
 
       // Check thumbnail link points to Amazon.co.jp
       const thumbnailLink = card.children[0] as { type: string; url: string };
-      expect(thumbnailLink.url).toBe(
-        "https://www.amazon.co.jp/dp/0123456789",
-      );
+      expect(thumbnailLink.url).toBe("https://www.amazon.co.jp/dp/0123456789");
       expect(thumbnailLink.data).toEqual({
         hProperties: { target: "_blank", rel: "noopener sponsored" },
       });

--- a/packages/md-plugins/remark-plugins/embed/book.test.ts
+++ b/packages/md-plugins/remark-plugins/embed/book.test.ts
@@ -1,6 +1,6 @@
 import type { Directives } from "mdast-util-directive";
 import type { Parent } from "unist";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { BookTransformer, buildAmazonUrl, getBookInfo } from "./book";
 
 vi.mock("../../cache", () => ({
@@ -44,11 +44,6 @@ describe("getBookInfo", () => {
 });
 
 describe("buildAmazonUrl", () => {
-  afterEach(() => {
-    process.env.AMAZON_ASSOCIATE_TAG_JP = "";
-    process.env.AMAZON_ASSOCIATE_TAG_US = "";
-  });
-
   it("generates Amazon.co.jp URL for jp region", () => {
     const url = buildAmazonUrl("0123456789", "jp");
     expect(url).toBe("https://www.amazon.co.jp/dp/0123456789");
@@ -59,16 +54,19 @@ describe("buildAmazonUrl", () => {
     expect(url).toBe("https://www.amazon.com/dp/0123456789");
   });
 
-  it("includes JP associate tag when set", () => {
-    process.env.AMAZON_ASSOCIATE_TAG_JP = "mytag-22";
-    const url = buildAmazonUrl("0123456789", "jp");
+  it("includes associate tag when provided", () => {
+    const url = buildAmazonUrl("0123456789", "jp", "mytag-22");
     expect(url).toBe("https://www.amazon.co.jp/dp/0123456789?tag=mytag-22");
   });
 
-  it("includes US associate tag when set", () => {
-    process.env.AMAZON_ASSOCIATE_TAG_US = "mytag-20";
-    const url = buildAmazonUrl("0123456789", "us");
+  it("includes US associate tag when provided", () => {
+    const url = buildAmazonUrl("0123456789", "us", "mytag-20");
     expect(url).toBe("https://www.amazon.com/dp/0123456789?tag=mytag-20");
+  });
+
+  it("omits tag param when tag is undefined", () => {
+    const url = buildAmazonUrl("0123456789", "jp", undefined);
+    expect(url).toBe("https://www.amazon.co.jp/dp/0123456789");
   });
 });
 
@@ -140,11 +138,6 @@ describe("BookTransformer", () => {
   });
 
   describe("transform", () => {
-    afterEach(() => {
-      process.env.AMAZON_ASSOCIATE_TAG_JP = "";
-      process.env.AMAZON_ASSOCIATE_TAG_US = "";
-    });
-
     it("generates a book card with Amazon.co.jp link by default", async () => {
       const transformer = new BookTransformer();
       const node = {
@@ -166,7 +159,7 @@ describe("BookTransformer", () => {
         hProperties: { className: "book-card" },
       });
 
-      // Check thumbnail link points to Amazon.co.jp
+      // Check thumbnail link points to Amazon.co.jp (no tag by default)
       const thumbnailLink = card.children[0] as unknown as {
         type: string;
         url: string;
@@ -210,9 +203,10 @@ describe("BookTransformer", () => {
       });
     });
 
-    it("includes associate tag in URL when env var is set", async () => {
-      process.env.AMAZON_ASSOCIATE_TAG_JP = "test-22";
-      const transformer = new BookTransformer();
+    it("includes JP associate tag in URL when injected via constructor", async () => {
+      const transformer = new BookTransformer({
+        associateTagJp: "test-22",
+      });
       const node = {
         type: "leafDirective",
         name: "isbn",
@@ -233,6 +227,35 @@ describe("BookTransformer", () => {
       };
       expect(thumbnailLink.url).toBe(
         "https://www.amazon.co.jp/dp/0123456789?tag=test-22",
+      );
+    });
+
+    it("includes US associate tag for {#us} region", async () => {
+      const transformer = new BookTransformer({
+        associateTagJp: "jp-tag-22",
+        associateTagUs: "us-tag-20",
+      });
+      const node = {
+        type: "leafDirective",
+        name: "isbn",
+        attributes: { id: "us" },
+        children: [{ type: "text", value: "0123456789" }],
+      } as unknown as Directives;
+
+      const parent: Parent = {
+        type: "root",
+        children: [node],
+      };
+
+      await transformer.transform(node, 0, parent);
+
+      const card = parent.children[0] as Parent;
+      const thumbnailLink = card.children[0] as unknown as {
+        type: string;
+        url: string;
+      };
+      expect(thumbnailLink.url).toBe(
+        "https://www.amazon.com/dp/0123456789?tag=us-tag-20",
       );
     });
 

--- a/packages/md-plugins/remark-plugins/embed/book.test.ts
+++ b/packages/md-plugins/remark-plugins/embed/book.test.ts
@@ -445,7 +445,10 @@ describe("BookTransformer", () => {
         type: string;
         url: string;
         data: unknown;
-        children: { type: string; children: { type: string; value: string }[] }[];
+        children: {
+          type: string;
+          children: { type: string; value: string }[];
+        }[];
       };
       expect(titleLink.type).toBe("link");
       expect(titleLink.url).toBe("https://www.amazon.co.jp/dp/0123456789");

--- a/packages/md-plugins/remark-plugins/embed/book.test.ts
+++ b/packages/md-plugins/remark-plugins/embed/book.test.ts
@@ -3,13 +3,7 @@ import type { Parent } from "unist";
 import { describe, expect, it, vi } from "vitest";
 import { BookTransformer, buildAmazonUrl, getBookInfo } from "./book";
 
-vi.mock("../../cache", () => ({
-  getCacheKey: vi.fn().mockReturnValue("test-key"),
-  cacheGet: vi.fn().mockResolvedValue(null),
-  cacheSet: vi.fn().mockResolvedValue(undefined),
-}));
-
-vi.mock("../../fetch", () => ({
+const { fetchWithRetry } = vi.hoisted(() => ({
   fetchWithRetry: vi.fn().mockResolvedValue({
     data: {
       items: [
@@ -27,6 +21,14 @@ vi.mock("../../fetch", () => ({
   }),
 }));
 
+vi.mock("../../cache", () => ({
+  getCacheKey: vi.fn().mockReturnValue("test-key"),
+  cacheGet: vi.fn().mockResolvedValue(null),
+  cacheSet: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("../../fetch", () => ({ fetchWithRetry }));
+
 describe("getBookInfo", () => {
   it("fetches and parses book info from Google Books API", async () => {
     const info = await getBookInfo("0123456789");
@@ -37,9 +39,57 @@ describe("getBookInfo", () => {
     expect(info.isbn).toBe("0123456789");
   });
 
+  it("constructs the correct Google Books API URL", async () => {
+    await getBookInfo("0123456789");
+    expect(fetchWithRetry).toHaveBeenCalledWith(
+      "https://www.googleapis.com/books/v1/volumes?q=isbn:0123456789",
+      undefined,
+    );
+  });
+
   it("handles ISBN-13", async () => {
     const info = await getBookInfo("9780123456789");
     expect(info.isbn).toBe("9780123456789");
+  });
+
+  it("throws when no items returned", async () => {
+    fetchWithRetry.mockResolvedValueOnce({
+      data: { items: [] },
+      status: 200,
+    });
+    await expect(getBookInfo("0000000000")).rejects.toThrow(
+      "No book found for ISBN: 0000000000",
+    );
+  });
+
+  it("throws when items is undefined", async () => {
+    fetchWithRetry.mockResolvedValueOnce({
+      data: {},
+      status: 200,
+    });
+    await expect(getBookInfo("0000000000")).rejects.toThrow(
+      "No book found for ISBN:",
+    );
+  });
+
+  it("falls back to empty values for missing optional fields", async () => {
+    fetchWithRetry.mockResolvedValueOnce({
+      data: {
+        items: [
+          {
+            volumeInfo: {
+              title: "Minimal Book",
+            },
+          },
+        ],
+      },
+      status: 200,
+    });
+    const info = await getBookInfo("1111111111");
+    expect(info.title).toBe("Minimal Book");
+    expect(info.description).toBe("");
+    expect(info.authors).toEqual([]);
+    expect(info.thumbnail).toBe("");
   });
 });
 
@@ -259,7 +309,194 @@ describe("BookTransformer", () => {
       );
     });
 
-    it("renders book title and authors from API response", async () => {
+    it("uses defaultRegion 'us' when set via constructor", async () => {
+      const transformer = new BookTransformer({
+        defaultRegion: "us",
+        associateTagUs: "us-tag-20",
+      });
+      const node = {
+        type: "leafDirective",
+        name: "isbn",
+        children: [{ type: "text", value: "0123456789" }],
+      } as unknown as Directives;
+
+      const parent: Parent = {
+        type: "root",
+        children: [node],
+      };
+
+      await transformer.transform(node, 0, parent);
+
+      const card = parent.children[0] as Parent;
+      const thumbnailLink = card.children[0] as unknown as {
+        type: string;
+        url: string;
+      };
+      expect(thumbnailLink.url).toBe(
+        "https://www.amazon.com/dp/0123456789?tag=us-tag-20",
+      );
+
+      // Button text should be English
+      const infoNode = card.children[1] as Parent;
+      const buttonNode = infoNode.children[2] as Parent;
+      expect(buttonNode.children[0]).toEqual({
+        type: "text",
+        value: "View on Amazon",
+      });
+    });
+
+    it("directive attribute overrides defaultRegion", async () => {
+      const transformer = new BookTransformer({
+        defaultRegion: "us",
+        associateTagJp: "jp-tag-22",
+      });
+      const node = {
+        type: "leafDirective",
+        name: "isbn",
+        attributes: { id: "jp" },
+        children: [{ type: "text", value: "0123456789" }],
+      } as unknown as Directives;
+
+      const parent: Parent = {
+        type: "root",
+        children: [node],
+      };
+
+      await transformer.transform(node, 0, parent);
+
+      const card = parent.children[0] as Parent;
+      const thumbnailLink = card.children[0] as unknown as {
+        type: string;
+        url: string;
+      };
+      expect(thumbnailLink.url).toBe(
+        "https://www.amazon.co.jp/dp/0123456789?tag=jp-tag-22",
+      );
+
+      // Button text should be Japanese despite defaultRegion=us
+      const infoNode = card.children[1] as Parent;
+      const buttonNode = infoNode.children[2] as Parent;
+      expect(buttonNode.children[0]).toEqual({
+        type: "text",
+        value: "Amazonで見る",
+      });
+    });
+
+    it("renders full card structure with correct hName and hProperties", async () => {
+      const transformer = new BookTransformer();
+      const node = {
+        type: "leafDirective",
+        name: "isbn",
+        children: [{ type: "text", value: "0123456789" }],
+      } as unknown as Directives;
+
+      const parent: Parent = {
+        type: "root",
+        children: [node],
+      };
+
+      await transformer.transform(node, 0, parent);
+
+      const card = parent.children[0] as Parent;
+
+      // Card wrapper
+      expect(card.data).toEqual({
+        hName: "div",
+        hProperties: { className: "book-card" },
+      });
+      expect(card.children).toHaveLength(2);
+
+      // Thumbnail link
+      const thumbnailLink = card.children[0] as unknown as {
+        type: string;
+        url: string;
+        data: unknown;
+        children: Parent[];
+      };
+      expect(thumbnailLink.type).toBe("link");
+      expect(thumbnailLink.data).toEqual({
+        hProperties: { target: "_blank", rel: "noopener sponsored" },
+      });
+
+      // Thumbnail image
+      const thumbnailImg = thumbnailLink.children[0] as unknown as {
+        type: string;
+        url: string;
+        alt: string;
+        data: unknown;
+      };
+      expect(thumbnailImg.type).toBe("image");
+      expect(thumbnailImg.url).toBe("https://example.com/thumb.jpg");
+      expect(thumbnailImg.alt).toBe("Test Book");
+      expect(thumbnailImg.data).toEqual({
+        hProperties: { className: "book-card-thumbnail" },
+      });
+
+      // Info node
+      const infoNode = card.children[1] as Parent;
+      expect(infoNode.data).toEqual({
+        hName: "div",
+        hProperties: { className: "book-card-info" },
+      });
+      expect(infoNode.children).toHaveLength(3);
+
+      // Title link
+      const titleLink = infoNode.children[0] as unknown as {
+        type: string;
+        url: string;
+        data: unknown;
+        children: { type: string; children: { type: string; value: string }[] }[];
+      };
+      expect(titleLink.type).toBe("link");
+      expect(titleLink.url).toBe("https://www.amazon.co.jp/dp/0123456789");
+      expect(titleLink.data).toEqual({
+        hProperties: { target: "_blank", rel: "noopener sponsored" },
+      });
+      expect(titleLink.children[0].type).toBe("strong");
+      expect(titleLink.children[0].children[0].value).toBe("Test Book");
+
+      // Authors node
+      const authorsNode = infoNode.children[1] as Parent;
+      expect(authorsNode.data).toEqual({
+        hName: "p",
+        hProperties: { className: "book-card-authors" },
+      });
+      expect(authorsNode.children[0]).toEqual({
+        type: "text",
+        value: "Author One, Author Two",
+      });
+
+      // Amazon button
+      const buttonNode = infoNode.children[2] as Parent;
+      expect(buttonNode.data).toEqual({
+        hName: "a",
+        hProperties: {
+          className: "book-card-amazon-link",
+          href: "https://www.amazon.co.jp/dp/0123456789",
+          target: "_blank",
+          rel: "noopener sponsored",
+        },
+      });
+      expect(buttonNode.children[0]).toEqual({
+        type: "text",
+        value: "Amazonで見る",
+      });
+    });
+
+    it("shows 'Unknown' when authors array is empty", async () => {
+      fetchWithRetry.mockResolvedValueOnce({
+        data: {
+          items: [
+            {
+              volumeInfo: {
+                title: "No Author Book",
+              },
+            },
+          ],
+        },
+        status: 200,
+      });
+
       const transformer = new BookTransformer();
       const node = {
         type: "leafDirective",
@@ -276,18 +513,10 @@ describe("BookTransformer", () => {
 
       const card = parent.children[0] as Parent;
       const infoNode = card.children[1] as Parent;
-
-      // Title link
-      const titleLink = infoNode.children[0] as unknown as {
-        children: { children: { value: string }[] }[];
-      };
-      expect(titleLink.children[0].children[0].value).toBe("Test Book");
-
-      // Authors
       const authorsNode = infoNode.children[1] as Parent;
       expect(authorsNode.children[0]).toEqual({
         type: "text",
-        value: "Author One, Author Two",
+        value: "Unknown",
       });
     });
   });

--- a/packages/md-plugins/remark-plugins/embed/book.test.ts
+++ b/packages/md-plugins/remark-plugins/embed/book.test.ts
@@ -1,4 +1,3 @@
-import type { Paragraph } from "mdast";
 import type { Directives } from "mdast-util-directive";
 import type { Parent } from "unist";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -161,14 +160,18 @@ describe("BookTransformer", () => {
 
       await transformer.transform(node, 0, parent);
 
-      const card = parent.children[0] as Paragraph;
+      const card = parent.children[0] as Parent;
       expect(card.data).toEqual({
         hName: "div",
         hProperties: { className: "book-card" },
       });
 
       // Check thumbnail link points to Amazon.co.jp
-      const thumbnailLink = card.children[0] as { type: string; url: string };
+      const thumbnailLink = card.children[0] as unknown as {
+        type: string;
+        url: string;
+        data: unknown;
+      };
       expect(thumbnailLink.url).toBe("https://www.amazon.co.jp/dp/0123456789");
       expect(thumbnailLink.data).toEqual({
         hProperties: { target: "_blank", rel: "noopener sponsored" },
@@ -191,13 +194,16 @@ describe("BookTransformer", () => {
 
       await transformer.transform(node, 0, parent);
 
-      const card = parent.children[0] as Paragraph;
-      const thumbnailLink = card.children[0] as { type: string; url: string };
+      const card = parent.children[0] as Parent;
+      const thumbnailLink = card.children[0] as unknown as {
+        type: string;
+        url: string;
+      };
       expect(thumbnailLink.url).toBe("https://www.amazon.com/dp/0123456789");
 
       // Check button text is English
-      const infoNode = card.children[1] as Paragraph;
-      const buttonNode = infoNode.children[2] as Paragraph;
+      const infoNode = card.children[1] as Parent;
+      const buttonNode = infoNode.children[2] as Parent;
       expect(buttonNode.children[0]).toEqual({
         type: "text",
         value: "View on Amazon",
@@ -220,8 +226,11 @@ describe("BookTransformer", () => {
 
       await transformer.transform(node, 0, parent);
 
-      const card = parent.children[0] as Paragraph;
-      const thumbnailLink = card.children[0] as { type: string; url: string };
+      const card = parent.children[0] as Parent;
+      const thumbnailLink = card.children[0] as unknown as {
+        type: string;
+        url: string;
+      };
       expect(thumbnailLink.url).toBe(
         "https://www.amazon.co.jp/dp/0123456789?tag=test-22",
       );
@@ -242,17 +251,17 @@ describe("BookTransformer", () => {
 
       await transformer.transform(node, 0, parent);
 
-      const card = parent.children[0] as Paragraph;
-      const infoNode = card.children[1] as Paragraph;
+      const card = parent.children[0] as Parent;
+      const infoNode = card.children[1] as Parent;
 
       // Title link
-      const titleLink = infoNode.children[0] as {
+      const titleLink = infoNode.children[0] as unknown as {
         children: { children: { value: string }[] }[];
       };
       expect(titleLink.children[0].children[0].value).toBe("Test Book");
 
       // Authors
-      const authorsNode = infoNode.children[1] as Paragraph;
+      const authorsNode = infoNode.children[1] as Parent;
       expect(authorsNode.children[0]).toEqual({
         type: "text",
         value: "Author One, Author Two",

--- a/packages/md-plugins/remark-plugins/embed/book.ts
+++ b/packages/md-plugins/remark-plugins/embed/book.ts
@@ -123,7 +123,10 @@ export class BookTransformer implements DirectiveTransformer {
         hProperties: { className: "book-card-authors" },
       },
       children: [
-        { type: "text", value: bookInfo.authors.join(", ") || "Unknown" } as Text,
+        {
+          type: "text",
+          value: bookInfo.authors.join(", ") || "Unknown",
+        } as Text,
       ],
     };
 

--- a/packages/md-plugins/remark-plugins/embed/book.ts
+++ b/packages/md-plugins/remark-plugins/embed/book.ts
@@ -43,18 +43,30 @@ export async function getBookInfo(isbn: string): Promise<BookInfo> {
   };
 }
 
-export function buildAmazonUrl(isbn: string, region: "jp" | "us"): string {
+export function buildAmazonUrl(
+  isbn: string,
+  region: "jp" | "us",
+  tag?: string,
+): string {
   const domain = region === "us" ? "www.amazon.com" : "www.amazon.co.jp";
-  const tag =
-    region === "us"
-      ? (process.env.AMAZON_ASSOCIATE_TAG_US ?? "")
-      : (process.env.AMAZON_ASSOCIATE_TAG_JP ?? "");
   const tagParam = tag ? `?tag=${tag}` : "";
   return `https://${domain}/dp/${isbn}${tagParam}`;
 }
 
+export type BookTransformerOptions = {
+  associateTagJp?: string;
+  associateTagUs?: string;
+};
+
 export class BookTransformer implements DirectiveTransformer {
   isbn?: string;
+  private associateTagJp: string;
+  private associateTagUs: string;
+
+  constructor(options?: BookTransformerOptions) {
+    this.associateTagJp = options?.associateTagJp ?? "";
+    this.associateTagUs = options?.associateTagUs ?? "";
+  }
 
   shouldTransform(node: Directives) {
     if (node.type !== "leafDirective") return false;
@@ -83,7 +95,8 @@ export class BookTransformer implements DirectiveTransformer {
         ? "us"
         : "jp";
 
-    const amazonUrl = buildAmazonUrl(isbn, region);
+    const tag = region === "us" ? this.associateTagUs : this.associateTagJp;
+    const amazonUrl = buildAmazonUrl(isbn, region, tag || undefined);
     const buttonText = region === "us" ? "View on Amazon" : "Amazonで見る";
 
     const thumbnailImage: Image = {

--- a/packages/md-plugins/remark-plugins/embed/book.ts
+++ b/packages/md-plugins/remark-plugins/embed/book.ts
@@ -1,4 +1,4 @@
-import type { Image, Link, Paragraph } from "mdast";
+import type { Image, Link, Text } from "mdast";
 import type { Directives } from "mdast-util-directive";
 import { toString as mdastToString } from "mdast-util-to-string";
 import type { Parent } from "unist";
@@ -43,12 +43,8 @@ export async function getBookInfo(isbn: string): Promise<BookInfo> {
   };
 }
 
-export function buildAmazonUrl(
-  isbn: string,
-  region: "jp" | "us",
-): string {
-  const domain =
-    region === "us" ? "www.amazon.com" : "www.amazon.co.jp";
+export function buildAmazonUrl(isbn: string, region: "jp" | "us"): string {
+  const domain = region === "us" ? "www.amazon.com" : "www.amazon.co.jp";
   const tag =
     region === "us"
       ? (process.env.AMAZON_ASSOCIATE_TAG_US ?? "")
@@ -120,19 +116,19 @@ export class BookTransformer implements DirectiveTransformer {
       ],
     };
 
-    const authorsNode: Paragraph = {
-      type: "paragraph",
+    const authorsNode: Parent = {
+      type: "book-card-authors",
       data: {
         hName: "p",
         hProperties: { className: "book-card-authors" },
       },
       children: [
-        { type: "text", value: bookInfo.authors.join(", ") || "Unknown" },
+        { type: "text", value: bookInfo.authors.join(", ") || "Unknown" } as Text,
       ],
     };
 
-    const amazonButton: Paragraph = {
-      type: "paragraph",
+    const amazonButton: Parent = {
+      type: "book-card-amazon-link",
       data: {
         hName: "a",
         hProperties: {
@@ -142,11 +138,11 @@ export class BookTransformer implements DirectiveTransformer {
           rel: "noopener sponsored",
         },
       },
-      children: [{ type: "text", value: buttonText }],
+      children: [{ type: "text", value: buttonText } as Text],
     };
 
-    const infoNode: Paragraph = {
-      type: "paragraph",
+    const infoNode: Parent = {
+      type: "book-card-info",
       data: {
         hName: "div",
         hProperties: { className: "book-card-info" },
@@ -154,8 +150,8 @@ export class BookTransformer implements DirectiveTransformer {
       children: [titleLink, authorsNode, amazonButton],
     };
 
-    const cardNode: Paragraph = {
-      type: "paragraph",
+    const cardNode: Parent = {
+      type: "book-card",
       data: {
         hName: "div",
         hProperties: { className: "book-card" },

--- a/packages/md-plugins/remark-plugins/embed/book.ts
+++ b/packages/md-plugins/remark-plugins/embed/book.ts
@@ -1,42 +1,64 @@
+import type { Image, Link, Paragraph } from "mdast";
 import type { Directives } from "mdast-util-directive";
 import { toString as mdastToString } from "mdast-util-to-string";
+import type { Parent } from "unist";
 import type { DirectiveTransformer } from ".";
-import { fetchWithRetry } from "../../fetch";
+import { cachedFetch } from "../../cachedFetch";
 
 type BookInfo = {
   title: string;
   description: string;
   authors: string[];
   thumbnail: string;
-  isbn10: string;
+  isbn: string;
 };
 
-export async function getBookInfo(isbn10: string): Promise<BookInfo> {
-  const url = `https://www.googleapis.com/books/v1/volumes?q=isbn:${isbn10}`;
+export async function getBookInfo(isbn: string): Promise<BookInfo> {
+  const url = `https://www.googleapis.com/books/v1/volumes?q=isbn:${isbn}`;
 
-  const resp = await fetchWithRetry<{
-    items: {
+  const resp = await cachedFetch(url);
+
+  const data = resp.data as {
+    items?: {
       volumeInfo: {
         title: string;
-        description: string;
-        authors: string[];
-        imageLinks: { thumbnail: string };
+        description?: string;
+        authors?: string[];
+        imageLinks?: { thumbnail?: string };
       };
     }[];
-  }>(url);
+  };
 
-  const book = resp.data.items[0].volumeInfo;
+  if (!data.items || data.items.length === 0) {
+    throw new Error(`No book found for ISBN: ${isbn}`);
+  }
+
+  const book = data.items[0].volumeInfo;
   return {
     title: book.title,
-    description: book.description,
-    authors: book.authors,
-    thumbnail: book.imageLinks.thumbnail,
-    isbn10: isbn10,
+    description: book.description ?? "",
+    authors: book.authors ?? [],
+    thumbnail: book.imageLinks?.thumbnail ?? "",
+    isbn,
   };
 }
 
+export function buildAmazonUrl(
+  isbn: string,
+  region: "jp" | "us",
+): string {
+  const domain =
+    region === "us" ? "www.amazon.com" : "www.amazon.co.jp";
+  const tag =
+    region === "us"
+      ? (process.env.AMAZON_ASSOCIATE_TAG_US ?? "")
+      : (process.env.AMAZON_ASSOCIATE_TAG_JP ?? "");
+  const tagParam = tag ? `?tag=${tag}` : "";
+  return `https://${domain}/dp/${isbn}${tagParam}`;
+}
+
 export class BookTransformer implements DirectiveTransformer {
-  isbn10?: string;
+  isbn?: string;
 
   shouldTransform(node: Directives) {
     if (node.type !== "leafDirective") return false;
@@ -44,14 +66,103 @@ export class BookTransformer implements DirectiveTransformer {
 
     const v = mdastToString(node);
 
-    if (v.length !== 10) {
+    if (v.length !== 10 && v.length !== 13) {
       return false;
     }
 
-    this.isbn10 = v;
+    this.isbn = v;
     return true;
   }
 
-  // @ts-ignore
-  async transform(node: Directives) {}
+  async transform(
+    node: Directives,
+    index: number | null | undefined,
+    parent: Parent,
+  ) {
+    const isbn = mdastToString(node);
+    const bookInfo = await getBookInfo(isbn);
+
+    const region: "jp" | "us" =
+      node.attributes && "id" in node.attributes && node.attributes.id === "us"
+        ? "us"
+        : "jp";
+
+    const amazonUrl = buildAmazonUrl(isbn, region);
+    const buttonText = region === "us" ? "View on Amazon" : "Amazonで見る";
+
+    const thumbnailImage: Image = {
+      type: "image",
+      url: bookInfo.thumbnail,
+      alt: bookInfo.title,
+      data: { hProperties: { className: "book-card-thumbnail" } },
+    };
+
+    const thumbnailLink: Link = {
+      type: "link",
+      url: amazonUrl,
+      data: {
+        hProperties: { target: "_blank", rel: "noopener sponsored" },
+      },
+      children: [thumbnailImage],
+    };
+
+    const titleLink: Link = {
+      type: "link",
+      url: amazonUrl,
+      data: {
+        hProperties: { target: "_blank", rel: "noopener sponsored" },
+      },
+      children: [
+        {
+          type: "strong",
+          children: [{ type: "text", value: bookInfo.title }],
+        },
+      ],
+    };
+
+    const authorsNode: Paragraph = {
+      type: "paragraph",
+      data: {
+        hName: "p",
+        hProperties: { className: "book-card-authors" },
+      },
+      children: [
+        { type: "text", value: bookInfo.authors.join(", ") || "Unknown" },
+      ],
+    };
+
+    const amazonButton: Paragraph = {
+      type: "paragraph",
+      data: {
+        hName: "a",
+        hProperties: {
+          className: "book-card-amazon-link",
+          href: amazonUrl,
+          target: "_blank",
+          rel: "noopener sponsored",
+        },
+      },
+      children: [{ type: "text", value: buttonText }],
+    };
+
+    const infoNode: Paragraph = {
+      type: "paragraph",
+      data: {
+        hName: "div",
+        hProperties: { className: "book-card-info" },
+      },
+      children: [titleLink, authorsNode, amazonButton],
+    };
+
+    const cardNode: Paragraph = {
+      type: "paragraph",
+      data: {
+        hName: "div",
+        hProperties: { className: "book-card" },
+      },
+      children: [thumbnailLink, infoNode],
+    };
+
+    parent.children[index || 0] = cardNode;
+  }
 }

--- a/packages/md-plugins/remark-plugins/embed/book.ts
+++ b/packages/md-plugins/remark-plugins/embed/book.ts
@@ -56,16 +56,19 @@ export function buildAmazonUrl(
 export type BookTransformerOptions = {
   associateTagJp?: string;
   associateTagUs?: string;
+  defaultRegion?: "jp" | "us";
 };
 
 export class BookTransformer implements DirectiveTransformer {
   isbn?: string;
   private associateTagJp: string;
   private associateTagUs: string;
+  private defaultRegion: "jp" | "us";
 
   constructor(options?: BookTransformerOptions) {
     this.associateTagJp = options?.associateTagJp ?? "";
     this.associateTagUs = options?.associateTagUs ?? "";
+    this.defaultRegion = options?.defaultRegion ?? "jp";
   }
 
   shouldTransform(node: Directives) {
@@ -90,10 +93,15 @@ export class BookTransformer implements DirectiveTransformer {
     const isbn = mdastToString(node);
     const bookInfo = await getBookInfo(isbn);
 
+    // Directive attribute {#us} or {#jp} overrides the default region
+    const explicitRegion =
+      node.attributes && "id" in node.attributes
+        ? (node.attributes.id as string)
+        : undefined;
     const region: "jp" | "us" =
-      node.attributes && "id" in node.attributes && node.attributes.id === "us"
-        ? "us"
-        : "jp";
+      explicitRegion === "us" || explicitRegion === "jp"
+        ? explicitRegion
+        : this.defaultRegion;
 
     const tag = region === "us" ? this.associateTagUs : this.associateTagJp;
     const amazonUrl = buildAmazonUrl(isbn, region, tag || undefined);

--- a/web/src/data/metrics-history.ndjson
+++ b/web/src/data/metrics-history.ndjson
@@ -7,3 +7,4 @@
 {"date":"2026-04-06","sha":"d7beedf","pr":141,"coverage":{"lines":73.11,"statements":70.68,"functions":66.8,"branches":63.76},"mutation":{"score":55.58,"killed":655,"survived":525,"timeout":2,"noCoverage":0,"total":1182}}
 {"date":"2026-04-08","sha":"b56d19e","pr":142,"coverage":{"lines":71.87,"statements":68.97,"functions":62.4,"branches":60.76},"mutation":{"score":55.58,"killed":655,"survived":525,"timeout":2,"noCoverage":0,"total":1182}}
 {"date":"2026-04-09","sha":"c07fbdc","pr":143,"coverage":{"lines":71.21,"statements":68.38,"functions":61.9,"branches":60.12},"mutation":{"score":55.58,"killed":655,"survived":525,"timeout":2,"noCoverage":0,"total":1182}}
+{"date":"2026-04-09","sha":"965898f","pr":144,"coverage":{"lines":71.68,"statements":68.86,"functions":62.45,"branches":61.43},"mutation":{"score":55.8,"killed":720,"survived":572,"timeout":2,"noCoverage":0,"total":1294}}

--- a/web/src/data/metrics-history.ndjson
+++ b/web/src/data/metrics-history.ndjson
@@ -7,4 +7,4 @@
 {"date":"2026-04-06","sha":"d7beedf","pr":141,"coverage":{"lines":73.11,"statements":70.68,"functions":66.8,"branches":63.76},"mutation":{"score":55.58,"killed":655,"survived":525,"timeout":2,"noCoverage":0,"total":1182}}
 {"date":"2026-04-08","sha":"b56d19e","pr":142,"coverage":{"lines":71.87,"statements":68.97,"functions":62.4,"branches":60.76},"mutation":{"score":55.58,"killed":655,"survived":525,"timeout":2,"noCoverage":0,"total":1182}}
 {"date":"2026-04-09","sha":"c07fbdc","pr":143,"coverage":{"lines":71.21,"statements":68.38,"functions":61.9,"branches":60.12},"mutation":{"score":55.58,"killed":655,"survived":525,"timeout":2,"noCoverage":0,"total":1182}}
-{"date":"2026-04-09","sha":"b5899db","pr":144,"coverage":{"lines":71.74,"statements":68.92,"functions":62.6,"branches":61.75},"mutation":{"score":55.92,"killed":725,"survived":573,"timeout":2,"noCoverage":0,"total":1300}}
+{"date":"2026-04-09","sha":"ecfcbd1","pr":144,"coverage":{"lines":71.89,"statements":69.06,"functions":62.6,"branches":62.95},"mutation":{"score":56.02,"killed":729,"survived":574,"timeout":2,"noCoverage":0,"total":1305}}

--- a/web/src/data/metrics-history.ndjson
+++ b/web/src/data/metrics-history.ndjson
@@ -7,4 +7,4 @@
 {"date":"2026-04-06","sha":"d7beedf","pr":141,"coverage":{"lines":73.11,"statements":70.68,"functions":66.8,"branches":63.76},"mutation":{"score":55.58,"killed":655,"survived":525,"timeout":2,"noCoverage":0,"total":1182}}
 {"date":"2026-04-08","sha":"b56d19e","pr":142,"coverage":{"lines":71.87,"statements":68.97,"functions":62.4,"branches":60.76},"mutation":{"score":55.58,"killed":655,"survived":525,"timeout":2,"noCoverage":0,"total":1182}}
 {"date":"2026-04-09","sha":"c07fbdc","pr":143,"coverage":{"lines":71.21,"statements":68.38,"functions":61.9,"branches":60.12},"mutation":{"score":55.58,"killed":655,"survived":525,"timeout":2,"noCoverage":0,"total":1182}}
-{"date":"2026-04-09","sha":"ecfcbd1","pr":144,"coverage":{"lines":71.89,"statements":69.06,"functions":62.6,"branches":62.95},"mutation":{"score":56.02,"killed":729,"survived":574,"timeout":2,"noCoverage":0,"total":1305}}
+{"date":"2026-04-09","sha":"a3853dd","pr":144,"coverage":{"lines":71.89,"statements":69.06,"functions":62.6,"branches":62.95},"mutation":{"score":56.02,"killed":729,"survived":574,"timeout":2,"noCoverage":0,"total":1305}}

--- a/web/src/data/metrics-history.ndjson
+++ b/web/src/data/metrics-history.ndjson
@@ -7,4 +7,4 @@
 {"date":"2026-04-06","sha":"d7beedf","pr":141,"coverage":{"lines":73.11,"statements":70.68,"functions":66.8,"branches":63.76},"mutation":{"score":55.58,"killed":655,"survived":525,"timeout":2,"noCoverage":0,"total":1182}}
 {"date":"2026-04-08","sha":"b56d19e","pr":142,"coverage":{"lines":71.87,"statements":68.97,"functions":62.4,"branches":60.76},"mutation":{"score":55.58,"killed":655,"survived":525,"timeout":2,"noCoverage":0,"total":1182}}
 {"date":"2026-04-09","sha":"c07fbdc","pr":143,"coverage":{"lines":71.21,"statements":68.38,"functions":61.9,"branches":60.12},"mutation":{"score":55.58,"killed":655,"survived":525,"timeout":2,"noCoverage":0,"total":1182}}
-{"date":"2026-04-09","sha":"965898f","pr":144,"coverage":{"lines":71.68,"statements":68.86,"functions":62.45,"branches":61.43},"mutation":{"score":55.8,"killed":720,"survived":572,"timeout":2,"noCoverage":0,"total":1294}}
+{"date":"2026-04-09","sha":"b5899db","pr":144,"coverage":{"lines":71.74,"statements":68.92,"functions":62.6,"branches":61.75},"mutation":{"score":55.92,"killed":725,"survived":573,"timeout":2,"noCoverage":0,"total":1300}}

--- a/web/src/features/articles/components/Post/MdxView.tsx
+++ b/web/src/features/articles/components/Post/MdxView.tsx
@@ -237,6 +237,52 @@ const style = css({
     py: 2,
   },
 
+  // book-card (Amazon affiliate)
+  "& div.book-card": {
+    display: "flex",
+    gap: 4,
+    p: 4,
+    my: 4,
+    borderWidth: 1,
+    borderColor: "border.default",
+    rounded: "lg",
+    bg: "bg.surface",
+    "& a": {
+      textDecoration: "none",
+    },
+    "& img.book-card-thumbnail": {
+      w: "120px",
+      h: "auto",
+      objectFit: "contain",
+      rounded: "md",
+      my: 0,
+      flexShrink: 0,
+    },
+    "& div.book-card-info": {
+      display: "flex",
+      flexDirection: "column",
+      gap: 1,
+    },
+    "& p.book-card-authors": {
+      color: "text.secondary",
+      fontSize: "sm",
+      my: 0,
+    },
+    "& a.book-card-amazon-link": {
+      display: "inline-block",
+      bg: "#FF9900",
+      color: "white",
+      px: 3,
+      py: 1,
+      rounded: "md",
+      fontSize: "sm",
+      mt: "auto",
+      w: "fit-content",
+      textDecoration: "none",
+      _hover: { bg: "#E68A00", color: "white" },
+    },
+  },
+
   // gh-meta
   "& span.gh-meta": {
     display: "inline-flex",


### PR DESCRIPTION
Complete the ::isbn directive to render book cards with Amazon affiliate links.
Google Books API fetches book info (cached), and cards link to Amazon.co.jp
(default) or Amazon.com (via {#us} attribute). Associate tags are read from
AMAZON_ASSOCIATE_TAG_JP / AMAZON_ASSOCIATE_TAG_US environment variables.

https://claude.ai/code/session_01VfHGSZSnqb6Rx81HHf3STE