### PR TITLE
Enhance CLI dump command logging and add single-file dump

### DIFF
--- a/cli/index.ts
+++ b/cli/index.ts
@@ -4,7 +4,7 @@ import yargs from "yargs";
 import { hideBin } from "yargs/helpers";
 import { exportDatabase } from "./exportNotion";
 import generateFeed from "./feed";
-import { getDumpPosts, writeDump } from "./io";
+import { dumpSinglePost, getDumpPosts, writeDump } from "./io";
 import { lintPosts } from "./lint";
 import { logger } from "./logger";
 import { generateRedirect } from "./migration";
@@ -44,6 +44,45 @@ yargs(hideBin(process.argv))
       const dumpPosts = await getDumpPosts(mdDir, imageDist);
       await writeDump(output, dumpPosts);
       logger.info({ count: dumpPosts.length, output }, "Dump complete");
+    },
+  )
+  .command(
+    "dump-file",
+    "Dump a single markdown file into json (for debugging)",
+    (yargs) => {
+      yargs.positional("file", {
+        type: "string",
+        describe: "Path to the markdown file",
+      });
+
+      yargs.positional("imageDist", {
+        type: "string",
+        describe: "Destination directory for optimized images",
+      });
+
+      yargs.option("output", {
+        type: "string",
+        describe: "Output file path (defaults to stdout)",
+        alias: ["o", "out"],
+      });
+
+      yargs.demandOption(["file", "imageDist"]);
+    },
+    async (argv) => {
+      const file = argv.file as string;
+      const imageDist = argv.imageDist as string;
+      const output = argv.output as string | undefined;
+
+      const result = await dumpSinglePost(file, imageDist);
+
+      const json = JSON.stringify(result, null, 2);
+      if (output) {
+        const { writeFile: writeFileAsync } = await import("node:fs/promises");
+        await writeFileAsync(output, json);
+        logger.info({ output }, "Single post dump written to file");
+      } else {
+        process.stdout.write(`${json}\n`);
+      }
     },
   )
   .command(

--- a/cli/io.test.ts
+++ b/cli/io.test.ts
@@ -1,6 +1,12 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 
 import { dumpPost, dumpSinglePost, getDumpPosts, readPost } from "./io";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const fixture = (...segments: string[]) => path.join(__dirname, ...segments);
+
 
 /**
  * Check whether Playwright browsers are installed.
@@ -26,7 +32,7 @@ const describeWithBrowser = hasBrowser ? describe : describe.skip;
 
 describe("readPost", () => {
   it("reads a valid post and returns meta + markdown", async () => {
-    const post = await readPost("./test/test1.md");
+    const post = await readPost(fixture("test", "test1.md"));
     expect(post.meta.uuid).toBe("61427e60-48c8-480b-bdbf-b5f846149c3a");
     expect(post.meta.title).toBe("Test Post");
     expect(post.meta.description).toBe("Test Description");
@@ -37,31 +43,31 @@ describe("readPost", () => {
   });
 
   it("throws on non-existent file", async () => {
-    await expect(readPost("./test/does-not-exist.md")).rejects.toThrow(
+    await expect(readPost(fixture("test", "does-not-exist.md"))).rejects.toThrow(
       "Failed to read post file",
     );
   });
 
   it("throws on invalid front-matter schema (missing required fields)", async () => {
     await expect(
-      readPost("./test-fixtures-invalid/test-invalid-yaml.md"),
+      readPost(fixture("test-fixtures-invalid", "test-invalid-yaml.md")),
     ).rejects.toThrow("Front-matter validation failed");
   });
 
   it("throws on malformed YAML front-matter", async () => {
     await expect(
-      readPost("./test-fixtures-invalid/test-bad-frontmatter.md"),
+      readPost(fixture("test-fixtures-invalid", "test-bad-frontmatter.md")),
     ).rejects.toThrow();
   });
 });
 
 describe("dumpPost", () => {
   it("compiles a post and returns DumpPost with expected fields", async () => {
-    const post = await readPost("./test/test1.md");
+    const post = await readPost(fixture("test", "test1.md"));
     const dumped = await dumpPost(
       post,
-      "./test/test1.md",
-      "./test/public/imageDist",
+      fixture("test", "test1.md"),
+      fixture("test", "public", "imageDist"),
     );
 
     expect(dumped.meta.uuid).toBe("61427e60-48c8-480b-bdbf-b5f846149c3a");
@@ -74,11 +80,11 @@ describe("dumpPost", () => {
   });
 
   it("extracts headings correctly", async () => {
-    const post = await readPost("./test/test1.md");
+    const post = await readPost(fixture("test", "test1.md"));
     const dumped = await dumpPost(
       post,
-      "./test/test1.md",
-      "./test/public/imageDist",
+      fixture("test", "test1.md"),
+      fixture("test", "public", "imageDist"),
     );
 
     expect(dumped.headings).toEqual([
@@ -89,11 +95,11 @@ describe("dumpPost", () => {
   });
 
   it("strips markdown heading syntax from rawMarkdown", async () => {
-    const post = await readPost("./test/test1.md");
+    const post = await readPost(fixture("test", "test1.md"));
     const dumped = await dumpPost(
       post,
-      "./test/test1.md",
-      "./test/public/imageDist",
+      fixture("test", "test1.md"),
+      fixture("test", "public", "imageDist"),
     );
 
     // rawMarkdown is the result of remark processing (headers extracted)
@@ -105,8 +111,8 @@ describe("dumpPost", () => {
 describe("dumpSinglePost", () => {
   it("dumps a single post without postMetaMap", async () => {
     const result = await dumpSinglePost(
-      "./test/test1.md",
-      "./test/public/imageDist",
+      fixture("test", "test1.md"),
+      fixture("test", "public", "imageDist"),
     );
 
     expect(result.meta.uuid).toBe("61427e60-48c8-480b-bdbf-b5f846149c3a");
@@ -117,15 +123,15 @@ describe("dumpSinglePost", () => {
 
   it("throws on non-existent file", async () => {
     await expect(
-      dumpSinglePost("./test/nope.md", "./test/public/imageDist"),
+      dumpSinglePost(fixture("test", "nope.md"), fixture("test", "public", "imageDist")),
     ).rejects.toThrow("Failed to read post file");
   });
 
   it("throws on invalid front-matter", async () => {
     await expect(
       dumpSinglePost(
-        "./test-fixtures-invalid/test-invalid-yaml.md",
-        "./test/public/imageDist",
+        fixture("test-fixtures-invalid", "test-invalid-yaml.md"),
+        fixture("test", "public", "imageDist"),
       ),
     ).rejects.toThrow("Front-matter validation failed");
   });
@@ -134,26 +140,26 @@ describe("dumpSinglePost", () => {
 describe("getDumpPosts", () => {
   it("returns empty array when no markdown files found", async () => {
     const result = await getDumpPosts(
-      "./test/public",
-      "./test/public/imageDist",
+      fixture("test", "public"),
+      fixture("test", "public", "imageDist"),
     );
     expect(result).toEqual([]);
   });
 
   it("fails when directory contains posts with invalid front-matter", async () => {
     await expect(
-      getDumpPosts("./test-fixtures-invalid", "./test/public/imageDist"),
+      getDumpPosts(fixture("test-fixtures-invalid"), fixture("test", "public", "imageDist")),
     ).rejects.toThrow("posts failed to process");
   });
 });
 
 describeWithBrowser("mermaid rendering", () => {
   it("renders mermaid code blocks to inline SVG at build time", async () => {
-    const post = await readPost("./test/test-mermaid.md");
+    const post = await readPost(fixture("test", "test-mermaid.md"));
     const dumped = await dumpPost(
       post,
-      "./test/test-mermaid.md",
-      "./test/public/imageDist",
+      fixture("test", "test-mermaid.md"),
+      fixture("test", "public", "imageDist"),
     );
     // rehype-mermaid with strategy "inline-svg" replaces the mermaid code
     // fence with an inline <svg>, which MDX compiles into JSX runtime calls
@@ -166,7 +172,7 @@ describeWithBrowser("mermaid rendering", () => {
 
 describeWithBrowser("internal links", () => {
   it("resolves .md links to internal URLs in getDumpPosts", async () => {
-    const posts = await getDumpPosts("./test", "./test/public/imageDist");
+    const posts = await getDumpPosts(fixture("test"), fixture("test", "public", "imageDist"));
 
     const test2 = posts.find(
       (p) => p.meta.uuid === "b2c3d4e5-f6a7-4b8c-9d0e-1f2a3b4c5d6e",

--- a/cli/io.test.ts
+++ b/cli/io.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { dumpPost, getDumpPosts, readPost } from "./io";
+import { dumpPost, dumpSinglePost, getDumpPosts, readPost } from "./io";
 
 /**
  * Check whether Playwright browsers are installed.
@@ -24,14 +24,126 @@ async function hasPlaywrightBrowser(): Promise<boolean> {
 const hasBrowser = await hasPlaywrightBrowser();
 const describeWithBrowser = hasBrowser ? describe : describe.skip;
 
-describe("test read post", () => {
-  it("sample read post", async () => {
-    await readPost("./test/test1.md");
+describe("readPost", () => {
+  it("reads a valid post and returns meta + markdown", async () => {
+    const post = await readPost("./test/test1.md");
+    expect(post.meta.uuid).toBe("61427e60-48c8-480b-bdbf-b5f846149c3a");
+    expect(post.meta.title).toBe("Test Post");
+    expect(post.meta.description).toBe("Test Description");
+    expect(post.meta.category).toBe("test");
+    expect(post.meta.lang).toBe("ja");
+    expect(post.meta.tags).toEqual(["tag1", "tag2"]);
+    expect(post.markdown).toContain("## heading2");
   });
 
-  it("dump smaple post", async () => {
+  it("throws on non-existent file", async () => {
+    await expect(readPost("./test/does-not-exist.md")).rejects.toThrow(
+      "Failed to read post file",
+    );
+  });
+
+  it("throws on invalid front-matter schema (missing required fields)", async () => {
+    await expect(
+      readPost("./test-fixtures-invalid/test-invalid-yaml.md"),
+    ).rejects.toThrow("Front-matter validation failed");
+  });
+
+  it("throws on malformed YAML front-matter", async () => {
+    await expect(
+      readPost("./test-fixtures-invalid/test-bad-frontmatter.md"),
+    ).rejects.toThrow();
+  });
+});
+
+describe("dumpPost", () => {
+  it("compiles a post and returns DumpPost with expected fields", async () => {
     const post = await readPost("./test/test1.md");
-    await dumpPost(post, "./test/test1.md", "./test/public/imageDist");
+    const dumped = await dumpPost(
+      post,
+      "./test/test1.md",
+      "./test/public/imageDist",
+    );
+
+    expect(dumped.meta.uuid).toBe("61427e60-48c8-480b-bdbf-b5f846149c3a");
+    expect(dumped.meta.title).toBe("Test Post");
+    expect(dumped.compiledMarkdown).toBeDefined();
+    expect(dumped.compiledMarkdown.length).toBeGreaterThan(0);
+    expect(dumped.rawMarkdown).toBeDefined();
+    expect(dumped.headings).toBeDefined();
+    expect(Array.isArray(dumped.headings)).toBe(true);
+  });
+
+  it("extracts headings correctly", async () => {
+    const post = await readPost("./test/test1.md");
+    const dumped = await dumpPost(
+      post,
+      "./test/test1.md",
+      "./test/public/imageDist",
+    );
+
+    expect(dumped.headings).toEqual([
+      { depth: 2, value: "heading2" },
+      { depth: 3, value: "heading3" },
+      { depth: 3, value: "heading4" },
+    ]);
+  });
+
+  it("strips markdown heading syntax from rawMarkdown", async () => {
+    const post = await readPost("./test/test1.md");
+    const dumped = await dumpPost(
+      post,
+      "./test/test1.md",
+      "./test/public/imageDist",
+    );
+
+    // rawMarkdown is the result of remark processing (headers extracted)
+    expect(dumped.rawMarkdown).toBeDefined();
+    expect(typeof dumped.rawMarkdown).toBe("string");
+  });
+});
+
+describe("dumpSinglePost", () => {
+  it("dumps a single post without postMetaMap", async () => {
+    const result = await dumpSinglePost(
+      "./test/test1.md",
+      "./test/public/imageDist",
+    );
+
+    expect(result.meta.uuid).toBe("61427e60-48c8-480b-bdbf-b5f846149c3a");
+    expect(result.meta.title).toBe("Test Post");
+    expect(result.compiledMarkdown).toBeDefined();
+    expect(result.headings.length).toBeGreaterThan(0);
+  });
+
+  it("throws on non-existent file", async () => {
+    await expect(
+      dumpSinglePost("./test/nope.md", "./test/public/imageDist"),
+    ).rejects.toThrow("Failed to read post file");
+  });
+
+  it("throws on invalid front-matter", async () => {
+    await expect(
+      dumpSinglePost(
+        "./test-fixtures-invalid/test-invalid-yaml.md",
+        "./test/public/imageDist",
+      ),
+    ).rejects.toThrow("Front-matter validation failed");
+  });
+});
+
+describe("getDumpPosts", () => {
+  it("returns empty array when no markdown files found", async () => {
+    const result = await getDumpPosts(
+      "./test/public",
+      "./test/public/imageDist",
+    );
+    expect(result).toEqual([]);
+  });
+
+  it("fails when directory contains posts with invalid front-matter", async () => {
+    await expect(
+      getDumpPosts("./test-fixtures-invalid", "./test/public/imageDist"),
+    ).rejects.toThrow("posts failed to process");
   });
 });
 

--- a/cli/io.ts
+++ b/cli/io.ts
@@ -105,12 +105,7 @@ export async function dumpPost(
         remarkPlugins: [
           [optimizeImage, { postPath, imageDist }],
           ...(postMetaMap
-            ? [
-                [
-                  resolveInternalLinks,
-                  { postPath: pathStr, postMetaMap },
-                ],
-              ]
+            ? [[resolveInternalLinks, { postPath: pathStr, postMetaMap }]]
             : []),
         ]
           .concat(
@@ -305,7 +300,11 @@ export async function dumpSinglePost(
   const post = await readPost(filePath);
 
   logger.info(
-    { title: post.meta.title, category: post.meta.category, uuid: post.meta.uuid },
+    {
+      title: post.meta.title,
+      category: post.meta.category,
+      uuid: post.meta.uuid,
+    },
     "Post metadata loaded",
   );
 

--- a/cli/io.ts
+++ b/cli/io.ts
@@ -30,6 +30,11 @@ import resolveInternalLinks, { type PostMetaMap } from "./resolveInternalLinks";
 
 const readFileAsync = promisify(readFile);
 
+function elapsed(startMs: number): string {
+  const ms = performance.now() - startMs;
+  return ms >= 1000 ? `${(ms / 1000).toFixed(2)}s` : `${Math.round(ms)}ms`;
+}
+
 export async function readPost(filePath: PathLike): Promise<Post> {
   let rawPost: string;
   try {
@@ -71,13 +76,18 @@ export async function dumpPost(
   imageDist: string,
   postMetaMap?: PostMetaMap,
 ): Promise<DumpPost> {
+  const startTime = performance.now();
+  const pathStr = String(postPath);
+
+  logger.debug({ postPath: pathStr, title: post.meta.title }, "Compiling post");
+
   let stripFile: Awaited<ReturnType<ReturnType<typeof remark>["process"]>>;
   try {
     // @ts-ignore
     stripFile = await remark().use(extractHeader).process(post.markdown);
   } catch (err) {
     logger.error(
-      { postPath: String(postPath), err },
+      { postPath: pathStr, err },
       "Failed to extract headers via remark",
     );
     throw new Error(`Failed to extract headers via remark: ${postPath}`);
@@ -98,7 +108,7 @@ export async function dumpPost(
             ? [
                 [
                   resolveInternalLinks,
-                  { postPath: String(postPath), postMetaMap },
+                  { postPath: pathStr, postMetaMap },
                 ],
               ]
             : []),
@@ -131,7 +141,7 @@ export async function dumpPost(
     );
   } catch (err) {
     logger.error(
-      { postPath: String(postPath), err },
+      { postPath: pathStr, err, elapsed: elapsed(startTime) },
       "Failed to compile markdown",
     );
     throw new Error(`Failed to compile markdown: ${postPath}`);
@@ -143,7 +153,7 @@ export async function dumpPost(
   if (!parsed.success) {
     logger.error(
       {
-        postPath: String(postPath),
+        postPath: pathStr,
         headings: _headings,
         validationError: parsed.error,
       },
@@ -151,6 +161,11 @@ export async function dumpPost(
     );
     throw new Error(`Failed to extract headers: ${postPath}`);
   }
+
+  logger.debug(
+    { postPath: pathStr, elapsed: elapsed(startTime) },
+    "Post compiled successfully",
+  );
 
   const { markdown: _, ...meta } = post;
   return {
@@ -165,6 +180,8 @@ export async function getDumpPosts(
   src: PathLike,
   imageDist: string,
 ): Promise<DumpPost[]> {
+  const totalStartTime = performance.now();
+
   const mdFiles = await Array.fromAsync(
     glob(`${src}/**/*.md`, { exclude: ["**/node_modules/**"] }),
   );
@@ -180,6 +197,9 @@ export async function getDumpPosts(
   );
 
   // Phase 1: Read all posts to build the metadata map
+  const phase1Start = performance.now();
+  logger.info("Phase 1: Reading posts and building metadata map");
+
   const readResults = await Promise.allSettled(
     mdFiles.map(async (f) => ({ filePath: f, post: await readPost(f) })),
   );
@@ -202,7 +222,22 @@ export async function getDumpPosts(
     }
   }
 
+  logger.info(
+    {
+      read: readSucceeded.length,
+      failed: readFailed.length,
+      elapsed: elapsed(phase1Start),
+    },
+    "Phase 1 complete",
+  );
+
   // Phase 2: Compile all posts with the complete metadata map
+  const phase2Start = performance.now();
+  logger.info(
+    { count: readSucceeded.length },
+    "Phase 2: Compiling posts with metadata map",
+  );
+
   const compileResults = await Promise.allSettled(
     readSucceeded.map(async ({ filePath, post }) => {
       return await dumpPost(post, filePath, imageDist, postMetaMap);
@@ -224,6 +259,16 @@ export async function getDumpPosts(
     }
   }
 
+  const compileFailed = failed.length - readFailed.length;
+  logger.info(
+    {
+      compiled: succeeded.length,
+      failed: compileFailed,
+      elapsed: elapsed(phase2Start),
+    },
+    "Phase 2 complete",
+  );
+
   if (failed.length > 0) {
     for (const f of failed) {
       logger.error({ file: f.file, err: f.reason }, "Failed to process post");
@@ -242,8 +287,41 @@ export async function getDumpPosts(
     );
   }
 
-  logger.info({ count: succeeded.length }, "All posts processed successfully");
+  logger.info(
+    { count: succeeded.length, totalElapsed: elapsed(totalStartTime) },
+    "All posts processed successfully",
+  );
   return succeeded;
+}
+
+export async function dumpSinglePost(
+  filePath: string,
+  imageDist: string,
+): Promise<DumpPost> {
+  const startTime = performance.now();
+
+  logger.info({ filePath }, "Dumping single post");
+
+  const post = await readPost(filePath);
+
+  logger.info(
+    { title: post.meta.title, category: post.meta.category, uuid: post.meta.uuid },
+    "Post metadata loaded",
+  );
+
+  const result = await dumpPost(post, filePath, imageDist);
+
+  logger.info(
+    {
+      filePath,
+      title: post.meta.title,
+      headings: result.headings.length,
+      elapsed: elapsed(startTime),
+    },
+    "Single post dump complete",
+  );
+
+  return result;
 }
 
 function getDump(dumpPosts: DumpPost[]): Dump {

--- a/cli/logger.ts
+++ b/cli/logger.ts
@@ -1,6 +1,7 @@
 import pino from "pino";
 
 export const logger = pino({
+  level: process.env.LOG_LEVEL ?? "info",
   transport: {
     target: "pino-pretty",
     options: {

--- a/cli/test-fixtures-invalid/test-bad-frontmatter.md
+++ b/cli/test-fixtures-invalid/test-bad-frontmatter.md
@@ -1,0 +1,6 @@
+---
+: invalid yaml [[[
+not: valid: yaml: here
+---
+
+Content after bad yaml.

--- a/cli/test-fixtures-invalid/test-invalid-yaml.md
+++ b/cli/test-fixtures-invalid/test-invalid-yaml.md
@@ -1,0 +1,5 @@
+---
+title: Missing Required Fields
+---
+
+This post is missing uuid, description, category, tags, lang, created_at, updated_at.

--- a/stryker.config.json
+++ b/stryker.config.json
@@ -14,11 +14,12 @@
   "mutate": [
     "packages/md-plugins/**/*.ts",
     "packages/ipynb2md/src/**/*.ts",
-    "cli/src/**/*.ts",
+    "cli/**/*.ts",
     "!**/*.test.ts",
     "!**/*.spec.ts",
     "!**/*.d.ts",
     "!**/vitest.config.ts",
+    "!**/tsup.config.ts",
     "!**/dist/**",
     "!**/node_modules/**"
   ]


### PR DESCRIPTION
- Add timing information (elapsed time) to all dump phases and per-post compilation
- Add phase-level progress logging (Phase 1: reading, Phase 2: compiling)
- Add debug-level per-post compilation logs (enabled via LOG_LEVEL=debug)
- Add `dump-file` subcommand for debugging single markdown files (outputs to stdout or file)
- Add `dumpSinglePost()` function for programmatic single-file dump
- Support LOG_LEVEL env var in logger configuration
- Strengthen tests: readPost validation errors, dumpPost field assertions, heading extraction,
  dumpSinglePost happy/error paths, getDumpPosts with invalid fixtures

https://claude.ai/code/session_017A6Q9YMuqYQnJ2MwMn8Wcs