### PR TITLE
Add comprehensive test coverage for mutation guards

### DIFF
--- a/cli/src/io.test.ts
+++ b/cli/src/io.test.ts
@@ -8,7 +8,6 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const cliRoot = path.resolve(__dirname, "..");
 const fixture = (...segments: string[]) => path.join(cliRoot, ...segments);
 
-
 /**
  * Check whether Playwright browsers are installed.
  * rehype-mermaid with strategy "inline-svg" requires mermaid-isomorphic which
@@ -44,9 +43,9 @@ describe("readPost", () => {
   });
 
   it("throws on non-existent file", async () => {
-    await expect(readPost(fixture("test", "does-not-exist.md"))).rejects.toThrow(
-      "Failed to read post file",
-    );
+    await expect(
+      readPost(fixture("test", "does-not-exist.md")),
+    ).rejects.toThrow("Failed to read post file");
   });
 
   it("throws on invalid front-matter schema (missing required fields)", async () => {
@@ -124,7 +123,10 @@ describe("dumpSinglePost", () => {
 
   it("throws on non-existent file", async () => {
     await expect(
-      dumpSinglePost(fixture("test", "nope.md"), fixture("test", "public", "imageDist")),
+      dumpSinglePost(
+        fixture("test", "nope.md"),
+        fixture("test", "public", "imageDist"),
+      ),
     ).rejects.toThrow("Failed to read post file");
   });
 
@@ -149,7 +151,10 @@ describe("getDumpPosts", () => {
 
   it("fails when directory contains posts with invalid front-matter", async () => {
     await expect(
-      getDumpPosts(fixture("test-fixtures-invalid"), fixture("test", "public", "imageDist")),
+      getDumpPosts(
+        fixture("test-fixtures-invalid"),
+        fixture("test", "public", "imageDist"),
+      ),
     ).rejects.toThrow("posts failed to process");
   });
 });
@@ -173,7 +178,10 @@ describeWithBrowser("mermaid rendering", () => {
 
 describeWithBrowser("internal links", () => {
   it("resolves .md links to internal URLs in getDumpPosts", async () => {
-    const posts = await getDumpPosts(fixture("test"), fixture("test", "public", "imageDist"));
+    const posts = await getDumpPosts(
+      fixture("test"),
+      fixture("test", "public", "imageDist"),
+    );
 
     const test2 = posts.find(
       (p) => p.meta.uuid === "b2c3d4e5-f6a7-4b8c-9d0e-1f2a3b4c5d6e",

--- a/cli/src/lintSeoMeta.test.ts
+++ b/cli/src/lintSeoMeta.test.ts
@@ -46,6 +46,8 @@ describe("lintSeoMeta", () => {
       const errors = lintSeoMeta(meta, DUMMY_PATH, EMPTY_LINES);
       expect(errors).toHaveLength(1);
       expect(errors[0].message).toContain("title is too long");
+      // Explicitly guards the "too long" ruleId field against mutation.
+      expect(errors[0].ruleId).toBe("seo-meta-length");
     });
 
     it("reports error when description is too short", () => {
@@ -181,5 +183,56 @@ notafield: value`;
     const raw = "# Just a heading\nSome content";
     const lines = extractFrontMatterLines(raw);
     expect(lines.size).toBe(0);
+  });
+
+  it("treats only trimmed --- as the front-matter delimiter", () => {
+    // Delimiters with surrounding whitespace must still open/close the block.
+    // If the trim() check is removed, the opening "  ---  " would not be
+    // recognised and the inner fields wouldn't be captured.
+    const raw = `  ---
+title: "Test"
+  ---
+ignored: value`;
+    const lines = extractFrontMatterLines(raw);
+    expect(lines.get("title")).toBe(2);
+    expect(lines.has("ignored")).toBe(false);
+  });
+
+  it("ignores field-like lines appearing before the opening delimiter", () => {
+    // The `inFrontMatter` guard must prevent capturing lines outside the block.
+    // If that conditional is forced to true, "pre: value" would get captured.
+    const raw = `pre: value
+---
+title: "Test"
+---`;
+    const lines = extractFrontMatterLines(raw);
+    expect(lines.has("pre")).toBe(false);
+    expect(lines.get("title")).toBe(3);
+  });
+
+  it("ignores indented field-like lines inside front-matter (anchored regex)", () => {
+    // `^(\w+):` must only match at the beginning of the line. An unanchored
+    // regex would wrongly capture the inner "nested" token on the indented line.
+    const raw = `---
+title: "Test"
+  nested: value
+---`;
+    const lines = extractFrontMatterLines(raw);
+    expect(lines.get("title")).toBe(2);
+    expect(lines.has("nested")).toBe(false);
+  });
+
+  it("skips lines inside front-matter that do not match the field pattern", () => {
+    // Blank / non-field lines must not cause the map to grow. If the
+    // `if (match)` guard is removed, destructuring a null match would throw.
+    const raw = `---
+title: "Test"
+
+# not a field
+---`;
+    expect(() => extractFrontMatterLines(raw)).not.toThrow();
+    const lines = extractFrontMatterLines(raw);
+    expect(lines.size).toBe(1);
+    expect(lines.get("title")).toBe(2);
   });
 });

--- a/packages/md-plugins/fetch.test.ts
+++ b/packages/md-plugins/fetch.test.ts
@@ -174,6 +174,47 @@ describe("fetchWithRetry", () => {
     expect(result.data).toBe("fallback");
   });
 
+  it("logs a retry warning with incrementing attempt number and exponential delay", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    let attempt = 0;
+    globalThis.fetch = vi.fn().mockImplementation(() => {
+      attempt++;
+      if (attempt < 3) {
+        return Promise.reject(new Error("network error"));
+      }
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        headers: new Headers({ "content-type": "text/plain" }),
+        text: () => Promise.resolve("ok"),
+      });
+    });
+
+    // maxRetries=2 keeps cumulative backoff under the default test timeout
+    // (1000ms + 2000ms = 3000ms) while still exercising two retry log lines.
+    await fetchWithRetry("https://example.com/retrylog", {}, 2);
+
+    // Two warnings emitted: after attempts 0 and 1, before the third succeeds.
+    expect(warnSpy).toHaveBeenCalledTimes(2);
+
+    const firstCall = warnSpy.mock.calls[0][0] as string;
+    const secondCall = warnSpy.mock.calls[1][0] as string;
+
+    // Exact attempt numbering (1-indexed human-facing).
+    expect(firstCall).toContain("attempt 1/2");
+    expect(secondCall).toContain("attempt 2/2");
+
+    // Exponential backoff: 1000, 2000 ms (not divided).
+    expect(firstCall).toContain("wait 1000ms");
+    expect(secondCall).toContain("wait 2000ms");
+
+    // URL is echoed in the warning.
+    expect(firstCall).toContain("https://example.com/retrylog");
+    expect(firstCall).toContain("[fetchWithRetry] Retrying");
+
+    warnSpy.mockRestore();
+  });
+
   it("retries on non-ok status before exhausting", async () => {
     let attempt = 0;
     globalThis.fetch = vi.fn().mockImplementation(() => {

--- a/packages/md-plugins/index.test.ts
+++ b/packages/md-plugins/index.test.ts
@@ -1,3 +1,7 @@
+import rehypeStringify from "rehype-stringify";
+import remarkParse from "remark-parse";
+import remarkRehype from "remark-rehype";
+import { unified } from "unified";
 import { describe, expect, it } from "vitest";
 import { REHYPE_PLUGINS, REMARK_LINT_PLUGINS, REMARK_PLUGINS } from "./index";
 
@@ -40,5 +44,36 @@ describe("plugin exports", () => {
         typeof plugin === "function" || Array.isArray(plugin),
       ).toBeTruthy();
     }
+  });
+
+  it("REMARK_PLUGINS pipeline transforms ::youtube leaf directives", async () => {
+    // Integration guard: the transformer list passed to
+    // remarkDirectiveEmbedGenerator must include a YouTubeTransformer
+    // (otherwise the ::youtube directive would fall through unhandled).
+    const processor = unified()
+      .use(remarkParse)
+      // Apply every plugin EXCEPT remarkMdx (the last entry), which would
+      // otherwise try to parse the input as MDX and break remark-stringify.
+      .use(REMARK_PLUGINS.slice(0, -1))
+      .use(remarkRehype)
+      .use(rehypeStringify);
+
+    const vfile = await processor.process("::youtube[dQw4w9WgXcQ]");
+    const html = String(vfile.value);
+    expect(html).toContain('src="https://www.youtube.com/embed/dQw4w9WgXcQ"');
+    expect(html).toContain("<iframe");
+  });
+
+  it("REMARK_PLUGINS pipeline transforms ::gh-card leaf directives", async () => {
+    // Integration guard: GithubCardTransformer must be in the transformer list.
+    const processor = unified()
+      .use(remarkParse)
+      .use(REMARK_PLUGINS.slice(0, -1))
+      .use(remarkRehype)
+      .use(rehypeStringify);
+
+    const vfile = await processor.process("::gh-card[user/repo]");
+    const html = String(vfile.value);
+    expect(html).toContain('class="gh-card"');
   });
 });

--- a/packages/md-plugins/remark-plugins/attachIdToHeadings.test.ts
+++ b/packages/md-plugins/remark-plugins/attachIdToHeadings.test.ts
@@ -94,7 +94,9 @@ describe("attachIdToHeadings", () => {
     const preAttach = () => (tree: import("mdast").Root) => {
       for (const child of tree.children) {
         if (child.type === "heading") {
-          child.data = { customFlag: true };
+          (child.data as unknown as Record<string, unknown>) = {
+            customFlag: true,
+          };
         }
       }
     };
@@ -119,8 +121,9 @@ describe("attachIdToHeadings", () => {
       .use(rehypeStringify)
       .process("## test heading");
 
-    const headingData = (vfile.data as { headingData: Record<string, unknown>[] })
-      .headingData;
+    const headingData = (
+      vfile.data as { headingData: Record<string, unknown>[] }
+    ).headingData;
     expect(headingData).toHaveLength(1);
     // If attachIdToHeadings overwrote node.data, customFlag would be lost.
     expect(headingData[0].customFlag).toBe(true);

--- a/packages/md-plugins/remark-plugins/attachIdToHeadings.test.ts
+++ b/packages/md-plugins/remark-plugins/attachIdToHeadings.test.ts
@@ -87,4 +87,43 @@ describe("attachIdToHeadings", () => {
     const html = String(vfile.value);
     expect(html).toBe("<p>Just a paragraph.</p>");
   });
+
+  it("preserves existing node.data set by a prior plugin", async () => {
+    // A prior plugin attaches custom data to headings; attachIdToHeadings
+    // must not clobber it, only augment with hName/hProperties.
+    const preAttach = () => (tree: import("mdast").Root) => {
+      for (const child of tree.children) {
+        if (child.type === "heading") {
+          child.data = { customFlag: true };
+        }
+      }
+    };
+
+    const vfile = await unified()
+      .use(remarkParse)
+      .use(preAttach)
+      .use(attachIdToHeadings, { depth: 3 })
+      .use(
+        // Capture post-plugin AST via a plugin that stashes heading data.
+        () => (tree: import("mdast").Root, file) => {
+          const headingData: unknown[] = [];
+          for (const child of tree.children) {
+            if (child.type === "heading") {
+              headingData.push(child.data);
+            }
+          }
+          (file.data as Record<string, unknown>).headingData = headingData;
+        },
+      )
+      .use(remarkRehype)
+      .use(rehypeStringify)
+      .process("## test heading");
+
+    const headingData = (vfile.data as { headingData: Record<string, unknown>[] })
+      .headingData;
+    expect(headingData).toHaveLength(1);
+    // If attachIdToHeadings overwrote node.data, customFlag would be lost.
+    expect(headingData[0].customFlag).toBe(true);
+    expect(headingData[0].hName).toBe("h2");
+  });
 });

--- a/packages/md-plugins/remark-plugins/codeTitle.test.ts
+++ b/packages/md-plugins/remark-plugins/codeTitle.test.ts
@@ -87,4 +87,22 @@ describe("codeTitle", () => {
     // title= produces empty string which is falsy, so no wrapping
     expect(html).not.toContain("code-title-container");
   });
+
+  it("rejects a lone title= entry with extra = segments", async () => {
+    // `title=a=b` has 3 split parts — the `kv.length !== 2` guard must drop it.
+    // If that guard is removed, "a" would wrongly render as the title.
+    const vfile = await processor.process("```js title=a=b\ncode\n```");
+    const html = String(vfile.value);
+    expect(html).not.toContain("code-title-container");
+    expect(html).not.toContain(">a</p>");
+  });
+
+  it("renders the title with both expected class names", async () => {
+    // Guards against class-name literals being mutated to empty strings.
+    const vfile = await processor.process("```js title=main.ts\nx\n```");
+    const html = String(vfile.value);
+    expect(html).toContain('class="code-title-container"');
+    expect(html).toContain('class="code-title"');
+    expect(html).toContain(">main.ts</p>");
+  });
 });

--- a/packages/md-plugins/remark-plugins/details.test.ts
+++ b/packages/md-plugins/remark-plugins/details.test.ts
@@ -64,7 +64,9 @@ Some other directive
   it("does not transform :details leaf or text directives", async () => {
     // Ensures `visit(ast, "containerDirective", ...)` filter holds: non-container
     // directives with name 'details' must not become <details> elements.
-    const vfile = await prosessor.process(":details[inline]\n\n::details[leaf]\n");
+    const vfile = await prosessor.process(
+      ":details[inline]\n\n::details[leaf]\n",
+    );
     const html = String(vfile.value);
     expect(html).not.toContain("<details>");
     expect(html).not.toContain("<summary>");

--- a/packages/md-plugins/remark-plugins/details.test.ts
+++ b/packages/md-plugins/remark-plugins/details.test.ts
@@ -47,4 +47,38 @@ Some details
       "<details><summary>Details</summary><p>Some details</p></details>",
     );
   });
+
+  it("does not transform non-details container directives", async () => {
+    // Ensures the early return `if (node.name !== "details") return;` branch
+    // is effective: a :::note directive must stay as the default <div>.
+    const vfile = await prosessor.process(`:::note[heads up]
+Some other directive
+:::
+`);
+
+    const html = String(vfile.value);
+    expect(html).not.toContain("<details>");
+    expect(html).not.toContain("<summary>");
+  });
+
+  it("does not transform :details leaf or text directives", async () => {
+    // Ensures `visit(ast, "containerDirective", ...)` filter holds: non-container
+    // directives with name 'details' must not become <details> elements.
+    const vfile = await prosessor.process(":details[inline]\n\n::details[leaf]\n");
+    const html = String(vfile.value);
+    expect(html).not.toContain("<details>");
+    expect(html).not.toContain("<summary>");
+  });
+
+  it("renders summary text as literal content (not an empty node)", async () => {
+    // Guards against the inner `type: "text"` in the summary child being
+    // mutated to an empty string — the summary text must render.
+    const vfile = await prosessor.process(`:::details[タイトル]
+本文
+:::
+`);
+    const html = String(vfile.value);
+    expect(html).toContain("<summary>タイトル</summary>");
+    expect(html).toMatch(/>タイトル</);
+  });
 });

--- a/packages/md-plugins/remark-plugins/embed/book.test.ts
+++ b/packages/md-plugins/remark-plugins/embed/book.test.ts
@@ -121,6 +121,40 @@ describe("buildAmazonUrl", () => {
 });
 
 describe("BookTransformer", () => {
+  describe("constructor defaults", () => {
+    it("accepts being constructed with no arguments at all", () => {
+      // Guards the `options?.xxx` optional-chaining on the constructor arg:
+      // if any `?.` is removed, `new BookTransformer()` would throw because
+      // `undefined.associateTagJp` is a TypeError.
+      expect(() => new BookTransformer()).not.toThrow();
+    });
+
+    it("falls back to the JP region when no options are provided", async () => {
+      // Indirectly verifies that `defaultRegion ?? \"jp\"` is active: a
+      // mutation replacing `"jp"` with `""` would break the default region.
+      const transformer = new BookTransformer();
+      const node = {
+        type: "leafDirective",
+        name: "isbn",
+        children: [{ type: "text", value: "0123456789" }],
+      } as unknown as Directives;
+      const parent: Parent = { type: "root", children: [node] };
+      await transformer.transform(node, 0, parent);
+
+      const card = parent.children[0] as Parent;
+      const thumbnailLink = card.children[0] as unknown as { url: string };
+      expect(thumbnailLink.url).toBe("https://www.amazon.co.jp/dp/0123456789");
+
+      // Button label must be the Japanese default.
+      const infoNode = card.children[1] as Parent;
+      const buttonNode = infoNode.children[2] as Parent;
+      expect(buttonNode.children[0]).toEqual({
+        type: "text",
+        value: "Amazonで見る",
+      });
+    });
+  });
+
   describe("shouldTransform", () => {
     const transformer = new BookTransformer();
 

--- a/packages/md-plugins/remark-plugins/embed/doi.test.ts
+++ b/packages/md-plugins/remark-plugins/embed/doi.test.ts
@@ -51,6 +51,18 @@ describe("doiRegExp", () => {
   it("rejects DOI without slash", () => {
     expect(doiRegExp.test("10.1126")).toBe(false);
   });
+
+  it("rejects DOI with leading non-DOI prefix (anchored start)", () => {
+    // Without the ^ anchor, the regex would find "10.1234/xyz" inside the string.
+    expect(doiRegExp.test("abc10.1234/xyz")).toBe(false);
+  });
+
+  it("rejects DOI with trailing invalid characters (anchored end)", () => {
+    // Without the $ anchor, the regex would match the valid DOI prefix
+    // and ignore the trailing garbage.
+    expect(doiRegExp.test("10.1234/xyz trailing stuff")).toBe(false);
+    expect(doiRegExp.test("10.1234/xyz?extra")).toBe(false);
+  });
 });
 
 describe("DoiTransformer.shouldTransform", () => {

--- a/packages/md-plugins/remark-plugins/embed/github-card.test.ts
+++ b/packages/md-plugins/remark-plugins/embed/github-card.test.ts
@@ -1,3 +1,4 @@
+import type { Directives } from "mdast-util-directive";
 import { describe, expect, it } from "vitest";
 
 import rehypeStringify from "rehype-stringify";
@@ -56,5 +57,43 @@ describe("github-card embed", () => {
     );
 
     console.log(vfile);
+  });
+
+  describe("shouldTransform", () => {
+    const transformer = new GithubCardTransformer();
+
+    it("returns true for leafDirective named 'gh-card'", () => {
+      const node = {
+        type: "leafDirective",
+        name: "gh-card",
+        children: [{ type: "text", value: "user/repo" }],
+      } as unknown as Directives;
+      expect(transformer.shouldTransform(node)).toBe(true);
+    });
+
+    it("returns false for non-leafDirective with name 'gh-card'", () => {
+      const node = {
+        type: "textDirective",
+        name: "gh-card",
+        children: [{ type: "text", value: "user/repo" }],
+      } as unknown as Directives;
+      expect(transformer.shouldTransform(node)).toBe(false);
+    });
+
+    it("returns false for leafDirective with a different name", () => {
+      const node = {
+        type: "leafDirective",
+        name: "youtube",
+        children: [{ type: "text", value: "abc" }],
+      } as unknown as Directives;
+      expect(transformer.shouldTransform(node)).toBe(false);
+    });
+
+    it("does not transform textDirective gh-card in rendered output", async () => {
+      // Full-pipeline guard: a text/container directive of the same name
+      // must not produce a <div class="gh-card"> wrapper.
+      const vfile = await processor.process(":gh-card[user/repo]");
+      expect(String(vfile.value)).not.toContain('class="gh-card"');
+    });
   });
 });

--- a/packages/md-plugins/remark-plugins/embed/youtube.test.ts
+++ b/packages/md-plugins/remark-plugins/embed/youtube.test.ts
@@ -1,3 +1,4 @@
+import type { Directives } from "mdast-util-directive";
 import { describe, expect, it } from "vitest";
 
 import rehypeStringify from "rehype-stringify";
@@ -24,5 +25,41 @@ describe("test youtube embed", () => {
     expect(vile.value).toStrictEqual(
       '<iframe id="ytplayer" class="youtube-embed" src="https://www.youtube.com/embed/NXTO3m1B_h4"></iframe>',
     );
+  });
+
+  describe("shouldTransform", () => {
+    const transformer = new YouTubeTransformer();
+
+    it("returns true for leafDirective named 'youtube'", () => {
+      const node = {
+        type: "leafDirective",
+        name: "youtube",
+        children: [{ type: "text", value: "abc" }],
+      } as unknown as Directives;
+      expect(transformer.shouldTransform(node)).toBe(true);
+    });
+
+    it("returns false for non-leafDirective with name 'youtube'", () => {
+      const node = {
+        type: "textDirective",
+        name: "youtube",
+        children: [{ type: "text", value: "abc" }],
+      } as unknown as Directives;
+      expect(transformer.shouldTransform(node)).toBe(false);
+    });
+
+    it("returns false for leafDirective with a different name", () => {
+      const node = {
+        type: "leafDirective",
+        name: "gh-card",
+        children: [{ type: "text", value: "user/repo" }],
+      } as unknown as Directives;
+      expect(transformer.shouldTransform(node)).toBe(false);
+    });
+
+    it("does not render an iframe for :youtube text directive", async () => {
+      const vfile = await processor.process(":youtube[NXTO3m1B_h4]");
+      expect(String(vfile.value)).not.toContain("<iframe");
+    });
   });
 });

--- a/packages/md-plugins/remark-plugins/figure.test.ts
+++ b/packages/md-plugins/remark-plugins/figure.test.ts
@@ -62,4 +62,27 @@ Some details
     expect(String(vfile.value)).not.toContain("<figure>");
     expect(String(vfile.value)).not.toContain("<figcaption>");
   });
+
+  it("does not transform leafDirective or textDirective with name 'figure'", async () => {
+    // Ensures the `visit(ast, "containerDirective", ...)` filter is effective:
+    // a `::figure` leaf/text directive must not get a figcaption attached.
+    const vfile = await processor.process(
+      ":figure[inline]\n\n::figure[leaf]\n",
+    );
+    expect(String(vfile.value)).not.toContain("<figure>");
+    expect(String(vfile.value)).not.toContain("<figcaption>");
+  });
+
+  it("produces figcaption text nodes that render as visible text", async () => {
+    // Guards against the inner `type: "text"` of the figcaption child being
+    // mutated to an empty string (which would drop the caption text).
+    const vfile = await processor.process(`:::figure[キャプション]
+![img](./img.png)
+:::
+`);
+    const html = String(vfile.value);
+    expect(html).toContain("<figcaption>Figure 1: キャプション</figcaption>");
+    // Caption text must literally appear in the rendered HTML.
+    expect(html).toMatch(/Figure 1: キャプション/);
+  });
 });

--- a/packages/md-plugins/remark-plugins/lintUnrenderedEmphasis.test.ts
+++ b/packages/md-plugins/remark-plugins/lintUnrenderedEmphasis.test.ts
@@ -68,6 +68,12 @@ describe("remarkLintUnrenderedEmphasis", () => {
       const vfile = await createProcessor().process("** bold **");
       expect(vfile.messages).toHaveLength(1);
       expect(vfile.messages[0].message).toContain("** bold **");
+      // Message source should be the rule id passed to file.message.
+      expect(vfile.messages[0].ruleId).toBe("remark-lint-unrendered-emphasis");
+      // Exact message shape (guards against the template literal being blanked).
+      expect(vfile.messages[0].message).toBe(
+        'Unrendered emphasis found: "** bold **"',
+      );
     });
 
     it("detects **bold ** (trailing space)", async () => {
@@ -83,6 +89,28 @@ describe("remarkLintUnrenderedEmphasis", () => {
     it("detects *bold * (italic with trailing space)", async () => {
       const vfile = await createProcessor().process("*bold *");
       expect(vfile.messages).toHaveLength(1);
+      expect(vfile.messages[0].ruleId).toBe("remark-lint-unrendered-emphasis");
+      // Exact italic message shape (guards the italic branch template literal).
+      expect(vfile.messages[0].message).toBe(
+        'Unrendered emphasis found: "*bold *"',
+      );
+    });
+
+    it("detects *bold* with only leading inner space (italic branch)", async () => {
+      // Inner is " bold": starts with space, does NOT end with space → reported.
+      // Ensures the endsWith(" ") half of the filter is exercised.
+      // Surrounded by CJK so *…* parses as a text node (not rendered emphasis).
+      const vfile = await createProcessor().process("あ* bold*い");
+      expect(vfile.messages).toHaveLength(1);
+      expect(vfile.messages[0].message).toContain("* bold*");
+    });
+
+    it("detects *bold* with only trailing inner space using non-emphasis context", async () => {
+      // Inner is "bold ": does NOT start with space, ends with space → reported.
+      // Ensures the startsWith(" ") half of the filter is exercised.
+      const vfile = await createProcessor().process("あ*bold *い");
+      expect(vfile.messages).toHaveLength(1);
+      expect(vfile.messages[0].message).toContain("*bold *");
     });
 
     it("detects unrendered emphasis with CJK surroundings", async () => {

--- a/web/src/data/metrics-history.ndjson
+++ b/web/src/data/metrics-history.ndjson
@@ -11,4 +11,4 @@
 {"date":"2026-04-09","sha":"0cf0ce5","pr":145,"coverage":{"lines":71.75,"statements":68.82,"functions":62.6,"branches":62.72},"mutation":{"score":59.08,"killed":769,"survived":534,"timeout":2,"noCoverage":0,"total":1305}}
 {"date":"2026-04-10","sha":"acc7ff7","pr":148,"coverage":{"lines":75.29,"statements":72.3,"functions":64.45,"branches":63.7},"mutation":{"score":41.05,"killed":941,"survived":1354,"timeout":2,"noCoverage":0,"total":2297}}
 {"date":"2026-04-10","sha":"a67aabd","pr":146,"coverage":{"lines":75.29,"statements":72.3,"functions":64.45,"branches":63.7},"mutation":{"score":41.05,"killed":941,"survived":1354,"timeout":2,"noCoverage":0,"total":2297}}
-{"date":"2026-04-10","sha":"1061747","pr":149,"coverage":{"lines":75.48,"statements":72.91,"functions":64.45,"branches":65.3},"mutation":{"score":42.53,"killed":975,"survived":1320,"timeout":2,"noCoverage":0,"total":2297}}
+{"date":"2026-04-10","sha":"42d297c","pr":149,"coverage":{"lines":75.48,"statements":72.91,"functions":64.45,"branches":65.3},"mutation":{"score":42.53,"killed":975,"survived":1320,"timeout":2,"noCoverage":0,"total":2297}}

--- a/web/src/data/metrics-history.ndjson
+++ b/web/src/data/metrics-history.ndjson
@@ -10,3 +10,4 @@
 {"date":"2026-04-09","sha":"a3853dd","pr":144,"coverage":{"lines":71.89,"statements":69.06,"functions":62.6,"branches":62.95},"mutation":{"score":56.02,"killed":729,"survived":574,"timeout":2,"noCoverage":0,"total":1305}}
 {"date":"2026-04-09","sha":"0cf0ce5","pr":145,"coverage":{"lines":71.75,"statements":68.82,"functions":62.6,"branches":62.72},"mutation":{"score":59.08,"killed":769,"survived":534,"timeout":2,"noCoverage":0,"total":1305}}
 {"date":"2026-04-10","sha":"acc7ff7","pr":148,"coverage":{"lines":75.29,"statements":72.3,"functions":64.45,"branches":63.7},"mutation":{"score":41.05,"killed":941,"survived":1354,"timeout":2,"noCoverage":0,"total":2297}}
+{"date":"2026-04-10","sha":"1061747","pr":149,"coverage":{"lines":75.48,"statements":72.91,"functions":64.45,"branches":65.3},"mutation":{"score":42.53,"killed":975,"survived":1320,"timeout":2,"noCoverage":0,"total":2297}}


### PR DESCRIPTION
## Summary
This PR adds extensive test coverage to guard against common mutations and regressions in the codebase. The new tests are designed to catch subtle bugs that could be introduced by code modifications, such as removing conditional checks, mutating string literals, or altering regex anchors.

## Key Changes

### Test Coverage Additions

**CLI & Core Utilities:**
- `lintSeoMeta.test.ts`: Added assertion to verify `ruleId` field is not mutated
- `io.test.ts`: Code formatting improvements (line wrapping for readability)

**Front-Matter Parsing (`extractFrontMatterLines`):**
- Test for trimmed delimiters with surrounding whitespace
- Test to ensure field-like lines before opening delimiter are ignored
- Test for indented field-like lines inside front-matter (anchored regex validation)
- Test for non-field lines that don't match the field pattern

**Markdown Plugins:**
- `attachIdToHeadings.test.ts`: Test that existing `node.data` set by prior plugins is preserved, not clobbered
- `fetch.test.ts`: Comprehensive test for retry logging with attempt numbering and exponential backoff
- `github-card.test.ts`: Tests for `shouldTransform` method covering leafDirective vs other directive types
- `youtube.test.ts`: Tests for `shouldTransform` method and text directive non-transformation
- `details.test.ts`: Tests for non-details directives, non-container directives, and summary text rendering
- `figure.test.ts`: Tests for leaf/text directive filtering and figcaption text node rendering
- `codeTitle.test.ts`: Tests for malformed title attributes and class name rendering
- `book.test.ts`: Tests for constructor defaults and fallback region behavior
- `lintUnrenderedEmphasis.test.ts`: Tests for exact message shapes and both italic/bold branches
- `doi.test.ts`: Tests for regex anchoring (start and end anchors)

**Integration Tests:**
- `index.test.ts`: Added pipeline integration tests for YouTube and GitHub Card transformers

## Notable Implementation Details

These tests are designed as **mutation guards** — they verify:
- Conditional branches are actually executed (e.g., `if (match)`, `if (node.name !== "details")`)
- String literals and class names are not accidentally blanked
- Regex patterns maintain proper anchoring (`^` and `$`)
- Optional chaining (`?.`) is properly used
- Template literals produce expected output
- Prior plugin data is not overwritten
- Exponential backoff calculations are correct
- Default values are properly applied

Each test includes detailed comments explaining what mutation it guards against, making the test suite a form of executable documentation.

https://claude.ai/code/session_01CU7K6MvJ6nLEo8PUhV4Zsi