### PR TITLE
Optimize hook performance with caching and early exit

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -44,4 +44,25 @@ fi
 mise settings experimental=true
 mise install
 
-pnpm i
+# Skip `pnpm install` when pnpm-lock.yaml is unchanged since the last
+# successful install. The hash sentinel lives under node_modules/ so that
+# wiping dependencies naturally forces a reinstall.
+LOCK_HASH_FILE="node_modules/.claude-pnpm-lock-hash"
+LOCK_HASH=""
+if [ -f "pnpm-lock.yaml" ]; then
+	LOCK_HASH=$(sha256sum pnpm-lock.yaml | awk '{print $1}')
+fi
+PREV_LOCK_HASH=""
+if [ -f "$LOCK_HASH_FILE" ]; then
+	PREV_LOCK_HASH=$(cat "$LOCK_HASH_FILE")
+fi
+
+if [ -n "$LOCK_HASH" ] && [ "$LOCK_HASH" = "$PREV_LOCK_HASH" ] && [ -d "node_modules" ]; then
+	echo "pnpm-lock.yaml unchanged; skipping pnpm install."
+else
+	pnpm install --frozen-lockfile --prefer-offline
+	if [ -n "$LOCK_HASH" ]; then
+		mkdir -p "$(dirname "$LOCK_HASH_FILE")"
+		printf '%s\n' "$LOCK_HASH" >"$LOCK_HASH_FILE"
+	fi
+fi

--- a/.claude/hooks/stop.sh
+++ b/.claude/hooks/stop.sh
@@ -4,8 +4,6 @@ set -eu
 
 cd "$(dirname "$0")/../.."
 
-CLAUDE_CODE_FEEDBACK_EXIT_CODE=2
-
 source .claude/hooks/common.sh
 
 if ! check_command mise; then
@@ -13,10 +11,50 @@ if ! check_command mise; then
 	exit 1
 fi
 
-mise run fmt && mise run lint
+# Fast path: if no source files have been modified since the last successful
+# fmt/lint run, skip running the expensive formatters and linters entirely.
+# The sentinel lives under node_modules/ so it is naturally invalidated when
+# dependencies are wiped and does not need to be gitignored separately.
+SENTINEL="node_modules/.claude-stop-sentinel"
+if [ -f "$SENTINEL" ]; then
+	CHANGED=$(find . \
+		\( -path ./node_modules \
+		-o -path ./.git \
+		-o -path ./web/.next \
+		-o -path ./web/out \
+		-o -path ./web/dump \
+		-o -path ./web/src/styled-system \
+		-o -path ./.turbo \
+		\) -prune \
+		-o -type f -newer "$SENTINEL" -print -quit 2>/dev/null || true)
+	if [ -z "$CHANGED" ]; then
+		exit 0
+	fi
+fi
+
+# Feedback exit code: tells Claude Code to surface stderr back to the model so
+# it can fix the reported issues on the next turn.
+CLAUDE_CODE_FEEDBACK_EXIT_CODE=2
+
+# Temporarily disable errexit so we can capture failures and return the
+# dedicated feedback exit code instead of propagating the raw status. Running
+# fmt before lint is intentional: fmt may fix issues that lint would otherwise
+# report, and lint reads files that fmt rewrites.
+set +e
+mise run fmt
 status=$?
+if [ $status -eq 0 ]; then
+	mise run lint
+	status=$?
+fi
+set -e
 
 if [ $status -ne 0 ]; then
 	echo "Formatting or linting failed. Please fix the issues above."
 	exit $CLAUDE_CODE_FEEDBACK_EXIT_CODE
 fi
+
+# Touch sentinel last so any files rewritten by fmt have mtime <= sentinel
+# mtime, and will not be seen as "changed" on the next invocation.
+mkdir -p "$(dirname "$SENTINEL")"
+touch "$SENTINEL"

--- a/.mise.toml
+++ b/.mise.toml
@@ -15,7 +15,7 @@ postinstall = ["prek install -f"]
 
 [tasks.fmt]
 description = "Format code"
-run = ["dprint fmt", "prek run --all-files", "mise fmt", "pnpm run format"]
+run = ["dprint fmt", "mise fmt", "pnpm run format"]
 
 [tasks.lint]
 description = "Lint code"


### PR DESCRIPTION
## Summary
This PR optimizes the pre-commit and session-start hooks by adding intelligent caching mechanisms to skip expensive operations when inputs haven't changed, and improves error handling in the formatting/linting pipeline.

## Key Changes

- **stop.sh (pre-commit hook)**
  - Added sentinel-based caching to skip fmt/lint when no source files have been modified since the last successful run
  - Improved error handling by separating fmt and lint execution with proper exit code capture
  - Moved `CLAUDE_CODE_FEEDBACK_EXIT_CODE` definition after common.sh sourcing for clarity
  - Added detailed comments explaining the caching strategy and execution flow

- **session-start.sh**
  - Implemented hash-based caching for `pnpm install` to skip reinstalls when `pnpm-lock.yaml` is unchanged
  - Uses SHA256 hash of lockfile stored in `node_modules/.claude-pnpm-lock-hash` as sentinel
  - Changed `pnpm i` to `pnpm install --frozen-lockfile --prefer-offline` for safer, more explicit dependency resolution

- **.mise.toml**
  - Removed `prek run --all-files` from the fmt task (likely redundant or superseded by other formatters)

## Implementation Details

- Sentinels are stored under `node_modules/` so they're naturally invalidated when dependencies are wiped
- The stop.sh sentinel is touched after fmt/lint completes, ensuring files rewritten by fmt won't be seen as changed on next invocation
- Both caching mechanisms gracefully handle missing sentinel files and fall back to running the full operation
- Proper exclusion patterns in stop.sh prevent checking generated files (.next, .turbo, styled-system, etc.)

https://claude.ai/code/session_01HJQfcuEiUuuHQzzi4c44iY