### PR TITLE
Add ORCID link to top page

### DIFF
--- a/web/src/app/[locale]/page.tsx
+++ b/web/src/app/[locale]/page.tsx
@@ -7,6 +7,7 @@ import { BookOpenIcon, DocumentTextIcon } from "@heroicons/react/24/outline";
 import type { Route } from "next";
 
 import GithubIcon from "@/icons/GithubIcon";
+import OrcidIcon from "@/icons/OrcidIcon";
 import TwitterIcon from "@/icons/TwitterIcon";
 import { type Locale, getDictionary, isLocale } from "@/lib/i18n";
 
@@ -131,6 +132,25 @@ export default async function Home({
               className={css({ h: 5, w: 5, fill: "currentColor" })}
             />
             <span>Twitter</span>
+          </a>
+          <a
+            href="https://orcid.org/0000-0002-3066-2940"
+            aria-label="ORCID"
+            target="_blank"
+            rel="noopener noreferrer"
+            className={css({
+              display: "flex",
+              alignItems: "center",
+              gap: 2,
+              color: "text.secondary",
+              fontSize: "sm",
+              transition: "colors",
+              transitionDuration: "fast",
+              _hover: { color: "accent.primary" },
+            })}
+          >
+            <OrcidIcon aria-hidden="true" className={css({ h: 5, w: 5 })} />
+            <span>ORCID</span>
           </a>
         </div>
 

--- a/web/src/app/[locale]/page.tsx
+++ b/web/src/app/[locale]/page.tsx
@@ -7,6 +7,7 @@ import { BookOpenIcon, DocumentTextIcon } from "@heroicons/react/24/outline";
 import type { Route } from "next";
 
 import GithubIcon from "@/icons/GithubIcon";
+import LinkedInIcon from "@/icons/LinkedInIcon";
 import OrcidIcon from "@/icons/OrcidIcon";
 import TwitterIcon from "@/icons/TwitterIcon";
 import { type Locale, getDictionary, isLocale } from "@/lib/i18n";
@@ -151,6 +152,25 @@ export default async function Home({
           >
             <OrcidIcon aria-hidden="true" className={css({ h: 5, w: 5 })} />
             <span>ORCID</span>
+          </a>
+          <a
+            href="https://www.linkedin.com/in/shogo-kawamura-77492b223"
+            aria-label="LinkedIn"
+            target="_blank"
+            rel="noopener noreferrer"
+            className={css({
+              display: "flex",
+              alignItems: "center",
+              gap: 2,
+              color: "text.secondary",
+              fontSize: "sm",
+              transition: "colors",
+              transitionDuration: "fast",
+              _hover: { color: "accent.primary" },
+            })}
+          >
+            <LinkedInIcon aria-hidden="true" className={css({ h: 5, w: 5 })} />
+            <span>LinkedIn</span>
           </a>
         </div>
 

--- a/web/src/data/metrics-history.ndjson
+++ b/web/src/data/metrics-history.ndjson
@@ -13,4 +13,4 @@
 {"date":"2026-04-10","sha":"a67aabd","pr":146,"coverage":{"lines":75.29,"statements":72.3,"functions":64.45,"branches":63.7},"mutation":{"score":41.05,"killed":941,"survived":1354,"timeout":2,"noCoverage":0,"total":2297}}
 {"date":"2026-04-10","sha":"42d297c","pr":149,"coverage":{"lines":75.48,"statements":72.91,"functions":64.45,"branches":65.3},"mutation":{"score":42.53,"killed":975,"survived":1320,"timeout":2,"noCoverage":0,"total":2297}}
 {"date":"2026-04-10","sha":"0edfe7a","pr":154,"coverage":{"lines":55.63,"statements":55.67,"functions":45.78,"branches":58.08},"mutation":{"score":43.58,"killed":999,"survived":1296,"timeout":2,"noCoverage":0,"total":2297}}
-{"date":"2026-04-10","sha":"19b7734","pr":152,"coverage":{"lines":75.48,"statements":72.91,"functions":64.45,"branches":65.3},"mutation":{"score":42.53,"killed":975,"survived":1320,"timeout":2,"noCoverage":0,"total":2297}}
+{"date":"2026-04-10","sha":"a4b29d6","pr":152,"coverage":{"lines":55.63,"statements":55.67,"functions":45.78,"branches":58.08},"mutation":{"score":42.53,"killed":975,"survived":1320,"timeout":2,"noCoverage":0,"total":2297}}

--- a/web/src/data/metrics-history.ndjson
+++ b/web/src/data/metrics-history.ndjson
@@ -12,3 +12,4 @@
 {"date":"2026-04-10","sha":"acc7ff7","pr":148,"coverage":{"lines":75.29,"statements":72.3,"functions":64.45,"branches":63.7},"mutation":{"score":41.05,"killed":941,"survived":1354,"timeout":2,"noCoverage":0,"total":2297}}
 {"date":"2026-04-10","sha":"a67aabd","pr":146,"coverage":{"lines":75.29,"statements":72.3,"functions":64.45,"branches":63.7},"mutation":{"score":41.05,"killed":941,"survived":1354,"timeout":2,"noCoverage":0,"total":2297}}
 {"date":"2026-04-10","sha":"42d297c","pr":149,"coverage":{"lines":75.48,"statements":72.91,"functions":64.45,"branches":65.3},"mutation":{"score":42.53,"killed":975,"survived":1320,"timeout":2,"noCoverage":0,"total":2297}}
+{"date":"2026-04-10","sha":"19b7734","pr":152,"coverage":{"lines":75.48,"statements":72.91,"functions":64.45,"branches":65.3},"mutation":{"score":42.53,"killed":975,"survived":1320,"timeout":2,"noCoverage":0,"total":2297}}

--- a/web/src/icons/LinkedInIcon.tsx
+++ b/web/src/icons/LinkedInIcon.tsx
@@ -1,0 +1,18 @@
+import type { SVGProps } from "react";
+
+const LinkedInIcon = (props: SVGProps<SVGSVGElement>) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 24 24"
+    {...props}
+    role="img"
+    aria-label="LinkedIn"
+  >
+    <path
+      fill="currentColor"
+      d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433a2.062 2.062 0 0 1-2.063-2.065 2.063 2.063 0 1 1 2.063 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z"
+    />
+  </svg>
+);
+
+export default LinkedInIcon;

--- a/web/src/icons/OrcidIcon.tsx
+++ b/web/src/icons/OrcidIcon.tsx
@@ -1,0 +1,22 @@
+import type { SVGProps } from "react";
+
+const OrcidIcon = (props: SVGProps<SVGSVGElement>) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 256 256"
+    {...props}
+    role="img"
+    aria-label="ORCID iD"
+  >
+    <path
+      fill="#A6CE39"
+      d="M256 128c0 70.7-57.3 128-128 128S0 198.7 0 128 57.3 0 128 0s128 57.3 128 128z"
+    />
+    <path
+      fill="#FFF"
+      d="M86.3 186.2H70.9V79.1h15.4v107.1zM108.9 79.1h41.6c39.6 0 57 28.3 57 53.6 0 27.5-21.5 53.6-56.8 53.6h-41.8V79.1zm15.4 93.3h24.5c34.9 0 42.9-26.5 42.9-39.7 0-21.5-13.7-39.7-43.7-39.7h-23.7v79.4zM88.7 56.8c0 5.5-4.5 10.1-10.1 10.1s-10.1-4.6-10.1-10.1c0-5.6 4.5-10.1 10.1-10.1s10.1 4.6 10.1 10.1z"
+    />
+  </svg>
+);
+
+export default OrcidIcon;


### PR DESCRIPTION
Display ORCID profile alongside GitHub and Twitter in the home page
social links using the official ORCID iD logo.