### PR TITLE
Prevent ipynb2md test from mutating committed fixture

### DIFF
--- a/cli/src/exportNotion/propertiesSchema.test.ts
+++ b/cli/src/exportNotion/propertiesSchema.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from "vitest";
+
+import { pageObjectSchema, propertiesSchema } from "./propertiesSchema";
+
+const validProperties = {
+  URL: { type: "url", url: "https://example.com" },
+  Github: { type: "url", url: "https://github.com/x/y" },
+  Name: {
+    id: "title-id",
+    type: "title",
+    title: [{ type: "text", plain_text: "Hello" }],
+  },
+  AiDesc: {
+    id: "desc-id",
+    type: "rich_text",
+    rich_text: [{ type: "text", plain_text: "description" }],
+  },
+  Tag: {
+    id: "tag-id",
+    type: "multi_select",
+    multi_select: [{ name: "ts" }, { name: "go" }],
+  },
+  Journal: {
+    id: "journal-id",
+    type: "multi_select",
+    multi_select: [{ name: "nature" }],
+  },
+};
+
+describe("propertiesSchema", () => {
+  it("parses a fully populated properties object", () => {
+    const parsed = propertiesSchema.parse(validProperties);
+    expect(parsed.Name.title[0].plain_text).toBe("Hello");
+    expect(parsed.Tag.multi_select.map((t) => t.name)).toEqual(["ts", "go"]);
+  });
+
+  it("allows Github url to be null", () => {
+    const parsed = propertiesSchema.parse({
+      ...validProperties,
+      Github: { type: "url", url: null },
+    });
+    expect(parsed.Github.url).toBeNull();
+  });
+
+  it("allows Github url to be undefined", () => {
+    const parsed = propertiesSchema.parse({
+      ...validProperties,
+      Github: { type: "url" },
+    });
+    expect(parsed.Github.url).toBeUndefined();
+  });
+
+  it("requires URL.url to be a string", () => {
+    expect(() =>
+      propertiesSchema.parse({
+        ...validProperties,
+        URL: { type: "url", url: null },
+      }),
+    ).toThrow();
+  });
+
+  it("rejects wrong type literal", () => {
+    expect(() =>
+      propertiesSchema.parse({
+        ...validProperties,
+        Name: {
+          id: "title-id",
+          type: "rich_text",
+          title: [],
+        },
+      }),
+    ).toThrow();
+  });
+
+  it("accepts empty multi_select arrays", () => {
+    const parsed = propertiesSchema.parse({
+      ...validProperties,
+      Tag: { id: "t", type: "multi_select", multi_select: [] },
+    });
+    expect(parsed.Tag.multi_select).toEqual([]);
+  });
+});
+
+describe("pageObjectSchema", () => {
+  it("parses a valid page object", () => {
+    const parsed = pageObjectSchema.parse({
+      id: "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+      created_time: "2024-01-01T00:00:00.000Z",
+      last_edited_time: "2024-02-01T00:00:00.000Z",
+      properties: validProperties,
+    });
+    expect(parsed.id).toBe("a1b2c3d4-e5f6-7890-abcd-ef1234567890");
+  });
+
+  it("rejects non-uuid id", () => {
+    expect(() =>
+      pageObjectSchema.parse({
+        id: "not-a-uuid",
+        created_time: "t",
+        last_edited_time: "t",
+        properties: validProperties,
+      }),
+    ).toThrow();
+  });
+});

--- a/cli/src/feed.test.ts
+++ b/cli/src/feed.test.ts
@@ -1,0 +1,91 @@
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import type { Dump } from "common";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import generateFeed from "./feed";
+
+function makeDump(): Dump {
+  return {
+    posts: [
+      {
+        meta: {
+          uuid: "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+          title: "First Post",
+          description: "A first post",
+          category: "techblog",
+          tags: ["ts"],
+          lang: "ja",
+          created_at: "2024-01-01",
+          updated_at: "2024-02-01",
+        },
+        rawMarkdown: "# First",
+        compiledMarkdown: "<h1>First</h1>",
+        headings: [{ depth: 1, value: "First" }],
+      },
+      {
+        meta: {
+          uuid: "a2b2c3d4-e5f6-7890-abcd-ef1234567890",
+          title: "Second Post",
+          description: "A second post",
+          category: "techblog",
+          tags: [],
+          lang: "ja",
+          created_at: "2024-03-01",
+          updated_at: "2024-04-01",
+        },
+        rawMarkdown: "# Second",
+        compiledMarkdown: "<h1>Second</h1>",
+        headings: [{ depth: 1, value: "Second" }],
+      },
+    ],
+    categories: ["techblog"],
+    tags: ["ts"],
+  };
+}
+
+describe("generateFeed", () => {
+  let workDir: string;
+  let dumpPath: string;
+  let dst: string;
+
+  beforeEach(() => {
+    workDir = mkdtempSync(path.join(tmpdir(), "feed-test-"));
+    dumpPath = path.join(workDir, "dump.json");
+    dst = path.join(workDir, "rss");
+    writeFileSync(dumpPath, JSON.stringify(makeDump()));
+  });
+
+  afterEach(() => {
+    rmSync(workDir, { recursive: true, force: true });
+  });
+
+  it("writes feed.xml, atom.xml, feed.json containing all posts", async () => {
+    await generateFeed(dumpPath, dst);
+
+    const rss = readFileSync(path.join(dst, "feed.xml"), "utf-8");
+    const atom = readFileSync(path.join(dst, "atom.xml"), "utf-8");
+    const json = readFileSync(path.join(dst, "feed.json"), "utf-8");
+
+    for (const body of [rss, atom, json]) {
+      expect(body).toContain("First Post");
+      expect(body).toContain("Second Post");
+      expect(body).toContain(
+        "techblog/post/a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+      );
+    }
+
+    // feed.json should be valid JSON
+    const parsed = JSON.parse(json);
+    expect(parsed.items).toHaveLength(2);
+  });
+
+  it("creates destination directory if it does not exist", async () => {
+    const nested = path.join(workDir, "nested", "deep", "rss");
+    await generateFeed(dumpPath, nested);
+    const rss = readFileSync(path.join(nested, "feed.xml"), "utf-8");
+    expect(rss).toContain("illumination-k.dev");
+  });
+});

--- a/cli/vitest.config.ts
+++ b/cli/vitest.config.ts
@@ -6,6 +6,8 @@ export default defineConfig({
       provider: "v8",
       reporter: ["text", "json", "json-summary", "html"],
       reportsDirectory: "./coverage",
+      include: ["src/**/*.ts"],
+      exclude: ["**/*.test.*", "**/*.d.ts", "src/index.ts"],
     },
   },
 });

--- a/packages/common/io.test.ts
+++ b/packages/common/io.test.ts
@@ -1,0 +1,76 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { Dump } from ".";
+import { readDump } from "./io";
+
+function makeValidDump(): Dump {
+  return {
+    posts: [
+      {
+        meta: {
+          uuid: "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+          title: "Hello",
+          description: "desc",
+          category: "techblog",
+          tags: ["ts"],
+          lang: "ja",
+          created_at: "2024-01-01",
+          updated_at: "2024-01-02",
+        },
+        rawMarkdown: "# Hello",
+        headings: [{ depth: 1, value: "Hello" }],
+        compiledMarkdown: "<h1>Hello</h1>",
+      },
+    ],
+    categories: ["techblog"],
+    tags: ["ts"],
+  };
+}
+
+describe("readDump", () => {
+  let workDir: string;
+
+  beforeEach(() => {
+    workDir = mkdtempSync(path.join(tmpdir(), "common-io-test-"));
+  });
+
+  afterEach(() => {
+    rmSync(workDir, { recursive: true, force: true });
+  });
+
+  it("parses a valid dump file", async () => {
+    const dumpPath = path.join(workDir, "dump.json");
+    writeFileSync(dumpPath, JSON.stringify(makeValidDump()));
+
+    const result = await readDump(dumpPath);
+
+    expect(result.posts).toHaveLength(1);
+    expect(result.posts[0].meta.title).toBe("Hello");
+    expect(result.categories).toEqual(["techblog"]);
+    expect(result.tags).toEqual(["ts"]);
+  });
+
+  it("throws when the dump fails schema validation", async () => {
+    const dumpPath = path.join(workDir, "dump.json");
+    writeFileSync(
+      dumpPath,
+      JSON.stringify({ posts: [], categories: "not-an-array", tags: [] }),
+    );
+
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await expect(readDump(dumpPath)).rejects.toBe("Invalid dump file");
+    expect(errorSpy).toHaveBeenCalled();
+
+    errorSpy.mockRestore();
+  });
+
+  it("rejects when the file does not exist", async () => {
+    await expect(
+      readDump(path.join(workDir, "missing.json")),
+    ).rejects.toBeDefined();
+  });
+});

--- a/packages/common/vitest.config.ts
+++ b/packages/common/vitest.config.ts
@@ -6,6 +6,8 @@ export default defineConfig({
       provider: "v8",
       reporter: ["text", "json", "json-summary", "html"],
       reportsDirectory: "./coverage",
+      include: ["*.ts"],
+      exclude: ["**/*.test.*", "**/*.d.ts", "vitest.config.*"],
     },
   },
 });

--- a/packages/ipynb2md/src/ipynb2md.test.ts
+++ b/packages/ipynb2md/src/ipynb2md.test.ts
@@ -1,7 +1,9 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import IpynbToMdContext from ".";
 
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -9,16 +11,25 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
 const IPYNB_PATH = path.join(__dirname, "../assets/test.ipynb");
-const OUTPUT_DIR = path.join(__dirname, "../assets/output");
 
 IpynbToMdContext.imageFileGenerator = (extension: string) =>
   `test.${extension}`;
 
 describe("ipynb2md", () => {
+  let outputDir: string;
+
+  beforeEach(() => {
+    outputDir = mkdtempSync(path.join(tmpdir(), "ipynb2md-test-"));
+  });
+
+  afterEach(() => {
+    rmSync(outputDir, { recursive: true, force: true });
+  });
+
   it("constructor IpynbToMdContext", () => {
     const context = IpynbToMdContext.from({
       ipynbFilePath: IPYNB_PATH,
-      outputDir: OUTPUT_DIR,
+      outputDir,
     });
 
     expect(context).toBeDefined();
@@ -27,16 +38,16 @@ describe("ipynb2md", () => {
   it("mdFilePath", () => {
     const context = IpynbToMdContext.from({
       ipynbFilePath: IPYNB_PATH,
-      outputDir: OUTPUT_DIR,
+      outputDir,
     });
 
-    expect(context.mdFilePath()).toBe(path.join(OUTPUT_DIR, "test.md"));
+    expect(context.mdFilePath()).toBe(path.join(outputDir, "test.md"));
   });
 
   it("writeMdFile", () => {
     const context = IpynbToMdContext.from({
       ipynbFilePath: IPYNB_PATH,
-      outputDir: OUTPUT_DIR,
+      outputDir,
     });
 
     context.writeMdFile();

--- a/packages/ipynb2md/vitest.config.ts
+++ b/packages/ipynb2md/vitest.config.ts
@@ -2,10 +2,12 @@ import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   test: {
+    exclude: ["node_modules/**", "dist/**"],
     coverage: {
       provider: "v8",
       reporter: ["text", "json", "json-summary", "html"],
       reportsDirectory: "./coverage",
+      exclude: ["dist/**", "**/*.test.*", "**/*.d.ts"],
     },
   },
 });

--- a/packages/md-plugins/vitest.config.ts
+++ b/packages/md-plugins/vitest.config.ts
@@ -7,7 +7,12 @@ export default defineConfig({
       reporter: ["text", "json", "json-summary", "html"],
       reportsDirectory: "./coverage",
       include: ["**/*.ts"],
-      exclude: ["**/*.test.*", "**/*.d.ts", "vitest.config.*", "node_modules/**"],
+      exclude: [
+        "**/*.test.*",
+        "**/*.d.ts",
+        "vitest.config.*",
+        "node_modules/**",
+      ],
     },
   },
 });

--- a/packages/md-plugins/vitest.config.ts
+++ b/packages/md-plugins/vitest.config.ts
@@ -6,6 +6,8 @@ export default defineConfig({
       provider: "v8",
       reporter: ["text", "json", "json-summary", "html"],
       reportsDirectory: "./coverage",
+      include: ["**/*.ts"],
+      exclude: ["**/*.test.*", "**/*.d.ts", "vitest.config.*", "node_modules/**"],
     },
   },
 });

--- a/web/src/app/_util/withZodPage.test.tsx
+++ b/web/src/app/_util/withZodPage.test.tsx
@@ -1,0 +1,96 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { z } from "zod";
+
+const notFoundMock = vi.fn(() => {
+  throw new Error("NEXT_NOT_FOUND");
+});
+
+vi.mock("next/navigation", () => ({
+  notFound: () => notFoundMock(),
+}));
+
+import { withZodPage } from "./withZodPage";
+
+describe("withZodPage", () => {
+  afterEach(() => {
+    notFoundMock.mockClear();
+    vi.unstubAllEnvs();
+  });
+
+  it("passes parsed params to the page when validation succeeds", async () => {
+    const schema = { params: z.object({ uuid: z.string() }) };
+    const page = vi.fn(() => "rendered");
+
+    const wrapped = withZodPage(schema, page);
+    const result = await wrapped({
+      params: Promise.resolve({ uuid: "abc" }),
+    });
+
+    expect(result).toBe("rendered");
+    expect(page).toHaveBeenCalledWith({ params: { uuid: "abc" } });
+  });
+
+  it("passes through both params and searchParams", async () => {
+    const schema = {
+      params: z.object({ slug: z.string() }),
+      searchParams: z.object({ page: z.coerce.number() }),
+    };
+    const page = vi.fn(() => null);
+
+    const wrapped = withZodPage(schema, page);
+    await wrapped({
+      params: Promise.resolve({ slug: "hello" }),
+      searchParams: Promise.resolve({ page: "3" }),
+    });
+
+    expect(page).toHaveBeenCalledWith({
+      params: { slug: "hello" },
+      searchParams: { page: 3 },
+    });
+  });
+
+  it("calls notFound when validation fails and no error handler is provided", async () => {
+    vi.stubEnv("NODE_ENV", "production");
+    const schema = { params: z.object({ uuid: z.string() }) };
+    const page = vi.fn(() => "rendered");
+
+    const wrapped = withZodPage(schema, page);
+
+    await expect(
+      wrapped({ params: Promise.resolve({ uuid: 123 }) }),
+    ).rejects.toThrow("NEXT_NOT_FOUND");
+    expect(notFoundMock).toHaveBeenCalledTimes(1);
+    expect(page).not.toHaveBeenCalled();
+  });
+
+  it("invokes the provided error handler instead of notFound", async () => {
+    const schema = { params: z.object({ uuid: z.string() }) };
+    const page = vi.fn(() => "rendered");
+    const errorHandler = vi.fn(() => "fallback");
+
+    const wrapped = withZodPage(schema, page, { params: errorHandler });
+    const result = await wrapped({
+      params: Promise.resolve({ uuid: 123 }),
+    });
+
+    expect(result).toBe("fallback");
+    expect(errorHandler).toHaveBeenCalledOnce();
+    expect(notFoundMock).not.toHaveBeenCalled();
+    expect(page).not.toHaveBeenCalled();
+  });
+
+  it("logs the zod error in development mode", async () => {
+    vi.stubEnv("NODE_ENV", "development");
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const schema = { params: z.object({ uuid: z.string() }) };
+    const page = vi.fn();
+
+    const wrapped = withZodPage(schema, page);
+    await expect(
+      wrapped({ params: Promise.resolve({ uuid: 123 }) }),
+    ).rejects.toThrow("NEXT_NOT_FOUND");
+    expect(errorSpy).toHaveBeenCalled();
+
+    errorSpy.mockRestore();
+  });
+});

--- a/web/src/app/_util/withZodPage.test.tsx
+++ b/web/src/app/_util/withZodPage.test.tsx
@@ -81,7 +81,9 @@ describe("withZodPage", () => {
 
   it("logs the zod error in development mode", async () => {
     vi.stubEnv("NODE_ENV", "development");
-    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {
+      // swallow zod error output in dev-mode assertion
+    });
     const schema = { params: z.object({ uuid: z.string() }) };
     const page = vi.fn();
 

--- a/web/src/data/metrics-history.ndjson
+++ b/web/src/data/metrics-history.ndjson
@@ -12,3 +12,4 @@
 {"date":"2026-04-10","sha":"acc7ff7","pr":148,"coverage":{"lines":75.29,"statements":72.3,"functions":64.45,"branches":63.7},"mutation":{"score":41.05,"killed":941,"survived":1354,"timeout":2,"noCoverage":0,"total":2297}}
 {"date":"2026-04-10","sha":"a67aabd","pr":146,"coverage":{"lines":75.29,"statements":72.3,"functions":64.45,"branches":63.7},"mutation":{"score":41.05,"killed":941,"survived":1354,"timeout":2,"noCoverage":0,"total":2297}}
 {"date":"2026-04-10","sha":"42d297c","pr":149,"coverage":{"lines":75.48,"statements":72.91,"functions":64.45,"branches":65.3},"mutation":{"score":42.53,"killed":975,"survived":1320,"timeout":2,"noCoverage":0,"total":2297}}
+{"date":"2026-04-10","sha":"0edfe7a","pr":154,"coverage":{"lines":55.63,"statements":55.67,"functions":45.78,"branches":58.08},"mutation":{"score":43.58,"killed":999,"survived":1296,"timeout":2,"noCoverage":0,"total":2297}}

--- a/web/src/features/articles/repository/dump.test.ts
+++ b/web/src/features/articles/repository/dump.test.ts
@@ -36,9 +36,17 @@ const UUID_C = "a3b2c3d4-e5f6-7890-abcd-ef1234567890";
 function makeDump(): Dump {
   return {
     posts: [
-      makePost(UUID_A, { tags: ["ts", "draft"], category: "techblog", lang: "ja" }),
+      makePost(UUID_A, {
+        tags: ["ts", "draft"],
+        category: "techblog",
+        lang: "ja",
+      }),
       makePost(UUID_A, { tags: ["ts"], category: "techblog", lang: "en" }),
-      makePost(UUID_B, { tags: ["go", "archive"], category: "paperstream", lang: "ja" }),
+      makePost(UUID_B, {
+        tags: ["go", "archive"],
+        category: "paperstream",
+        lang: "ja",
+      }),
       makePost(UUID_C, { tags: ["rust"], category: "techblog", lang: "ja" }),
     ],
     categories: ["techblog", "paperstream"],

--- a/web/src/features/articles/repository/dump.test.ts
+++ b/web/src/features/articles/repository/dump.test.ts
@@ -1,0 +1,136 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import type { Dump, DumpPost, Lang } from "common";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import DumpRepository from "./dump";
+
+function makePost(
+  uuid: string,
+  overrides: Partial<DumpPost["meta"]> = {},
+): DumpPost {
+  return {
+    meta: {
+      uuid,
+      title: `post-${uuid}`,
+      description: "",
+      category: "techblog",
+      tags: [],
+      lang: "ja" as Lang,
+      created_at: "2024-01-01",
+      updated_at: "2024-01-01",
+      ...overrides,
+    },
+    rawMarkdown: "",
+    compiledMarkdown: "",
+    headings: [],
+  };
+}
+
+const UUID_A = "a1b2c3d4-e5f6-7890-abcd-ef1234567890";
+const UUID_B = "a2b2c3d4-e5f6-7890-abcd-ef1234567890";
+const UUID_C = "a3b2c3d4-e5f6-7890-abcd-ef1234567890";
+
+function makeDump(): Dump {
+  return {
+    posts: [
+      makePost(UUID_A, { tags: ["ts", "draft"], category: "techblog", lang: "ja" }),
+      makePost(UUID_A, { tags: ["ts"], category: "techblog", lang: "en" }),
+      makePost(UUID_B, { tags: ["go", "archive"], category: "paperstream", lang: "ja" }),
+      makePost(UUID_C, { tags: ["rust"], category: "techblog", lang: "ja" }),
+    ],
+    categories: ["techblog", "paperstream"],
+    tags: ["ts", "go", "rust", "archive", "draft", "ts"],
+  };
+}
+
+describe("DumpRepository", () => {
+  let dumpPath: string;
+  let workDir: string;
+
+  beforeEach(() => {
+    workDir = mkdtempSync(path.join(tmpdir(), "dump-repo-test-"));
+    dumpPath = path.join(workDir, "dump.json");
+    writeFileSync(dumpPath, JSON.stringify(makeDump()));
+  });
+
+  afterEach(() => {
+    rmSync(workDir, { recursive: true, force: true });
+  });
+
+  it("retrieve returns the first match when lang is not provided", async () => {
+    const repo = new DumpRepository(dumpPath);
+    const post = await repo.retrieve(UUID_A);
+    expect(post.meta.uuid).toBe(UUID_A);
+    expect(post.meta.lang).toBe("ja");
+  });
+
+  it("retrieve prefers the lang-matching post when lang is provided", async () => {
+    const repo = new DumpRepository(dumpPath);
+    const post = await repo.retrieve(UUID_A, "en");
+    expect(post.meta.lang).toBe("en");
+  });
+
+  it("retrieve falls back to first candidate when lang does not match", async () => {
+    const repo = new DumpRepository(dumpPath);
+    const post = await repo.retrieve(UUID_A, "es");
+    expect(post.meta.lang).toBe("ja");
+  });
+
+  it("list returns all posts from dump", async () => {
+    const repo = new DumpRepository(dumpPath);
+    const posts = await repo.list();
+    expect(posts).toHaveLength(4);
+  });
+
+  it("caches the dump across repeated calls", async () => {
+    const repo = new DumpRepository(dumpPath);
+    const a = await repo.list();
+    // Delete the file: a second call must not try to read again
+    rmSync(dumpPath);
+    const b = await repo.list();
+    expect(b).toEqual(a);
+  });
+
+  it("categories returns dump categories", async () => {
+    const repo = new DumpRepository(dumpPath);
+    expect(await repo.categories()).toEqual(["techblog", "paperstream"]);
+  });
+
+  it("tags dedupes, sorts, and appends archive/draft at the end", async () => {
+    const repo = new DumpRepository(dumpPath);
+    const tags = await repo.tags();
+    expect(tags).toEqual(["go", "rust", "ts", "archive", "draft"]);
+  });
+
+  describe("filterPosts", () => {
+    it("filters by lang", async () => {
+      const repo = new DumpRepository(dumpPath);
+      const posts = await repo.filterPosts("en");
+      expect(posts).toHaveLength(1);
+      expect(posts[0].meta.lang).toBe("en");
+    });
+
+    it("filters by tag (note: current impl overwrites lang filter)", async () => {
+      const repo = new DumpRepository(dumpPath);
+      const posts = await repo.filterPosts("ja", "ts");
+      // Implementation reassigns `ok`, so the final predicate is the tag check.
+      expect(posts.map((p) => p.meta.uuid).sort()).toEqual([UUID_A, UUID_A]);
+    });
+
+    it("filters by category", async () => {
+      const repo = new DumpRepository(dumpPath);
+      const posts = await repo.filterPosts(undefined, undefined, "paperstream");
+      expect(posts).toHaveLength(1);
+      expect(posts[0].meta.category).toBe("paperstream");
+    });
+
+    it("returns all posts when no filters are given", async () => {
+      const repo = new DumpRepository(dumpPath);
+      const posts = await repo.filterPosts();
+      expect(posts).toHaveLength(4);
+    });
+  });
+});

--- a/web/src/features/articles/service.test.ts
+++ b/web/src/features/articles/service.test.ts
@@ -1,0 +1,133 @@
+import type { DumpPost, Lang, PostMeta } from "common";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { IBlogRepository } from "./irepository";
+import BlogService from "./service";
+
+function post(
+  uuid: string,
+  opts: {
+    lang?: Lang;
+    tags?: string[];
+  } = {},
+): DumpPost {
+  return {
+    meta: {
+      uuid,
+      title: `post-${uuid}`,
+      description: "",
+      category: "techblog",
+      tags: opts.tags ?? [],
+      lang: opts.lang ?? "ja",
+      created_at: "2024-01-01",
+      updated_at: "2024-01-01",
+    },
+    rawMarkdown: "",
+    compiledMarkdown: "",
+    headings: [],
+  };
+}
+
+function makeRepo(posts: DumpPost[]): IBlogRepository {
+  return {
+    list: async () => posts,
+    retrieve: async () => posts[0],
+    categories: async () => [],
+    tags: async () => [],
+    filterPosts: async () => posts,
+  };
+}
+
+function uuid(n: number): string {
+  const hex = n.toString(16).padStart(1, "0");
+  return `a${hex}b2c3d4-e5f6-7890-abcd-ef1234567890`;
+}
+
+const baseMeta = (u: string, tags: string[] = [], lang: Lang = "ja"): PostMeta => ({
+  uuid: u,
+  title: "t",
+  description: "",
+  category: "techblog",
+  tags,
+  lang,
+  created_at: "2024-01-01",
+  updated_at: "2024-01-01",
+});
+
+describe("BlogService.getRelatedPostMeta", () => {
+  beforeEach(() => {
+    // Deterministic shuffle: Math.random always returns 0, which makes the
+    // Fisher-Yates loop a no-op and preserves the input order.
+    vi.spyOn(Math, "random").mockReturnValue(0);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("excludes self, different lang, archive and draft posts", async () => {
+    const target = baseMeta(uuid(0), ["ts"]);
+    const repo = makeRepo([
+      post(uuid(0), { tags: ["ts"] }), // self
+      post(uuid(1), { tags: ["ts"], lang: "en" }), // wrong lang
+      post(uuid(2), { tags: ["archive"] }),
+      post(uuid(3), { tags: ["draft"] }),
+      post(uuid(4), { tags: ["ts"] }),
+    ]);
+
+    const svc = new BlogService(repo);
+    const result = await svc.getRelatedPostMeta(target);
+
+    expect(result.map((p) => p.uuid)).toEqual([uuid(4)]);
+  });
+
+  it("returns all candidates when fewer than maxRelPost (6)", async () => {
+    const target = baseMeta(uuid(0), ["ts"]);
+    const repo = makeRepo([
+      post(uuid(0)),
+      post(uuid(1), { tags: ["ts"] }),
+      post(uuid(2), { tags: ["go"] }),
+    ]);
+
+    const svc = new BlogService(repo);
+    const result = await svc.getRelatedPostMeta(target);
+
+    expect(result.map((p) => p.uuid).sort()).toEqual([uuid(1), uuid(2)].sort());
+  });
+
+  it("tops up with random posts when tag-matching is below maxRelPost", async () => {
+    const target = baseMeta(uuid(0), ["ts"]);
+    // 1 tag match + 6 non-tag-matching posts → should end up with 6
+    const repo = makeRepo([
+      post(uuid(0)),
+      post(uuid(1), { tags: ["ts"] }), // matches
+      post(uuid(2), { tags: ["go"] }),
+      post(uuid(3), { tags: ["rust"] }),
+      post(uuid(4), { tags: ["py"] }),
+      post(uuid(5), { tags: ["sh"] }),
+      post(uuid(6), { tags: ["md"] }),
+      post(uuid(7), { tags: ["js"] }),
+    ]);
+
+    const svc = new BlogService(repo);
+    const result = await svc.getRelatedPostMeta(target);
+
+    expect(result).toHaveLength(6);
+    expect(result.map((p) => p.uuid)).toContain(uuid(1));
+  });
+
+  it("slices to maxRelPost when more than 6 tag-matching posts exist", async () => {
+    const target = baseMeta(uuid(0), ["ts"]);
+    const repo = makeRepo([
+      post(uuid(0)),
+      ...Array.from({ length: 8 }, (_, i) =>
+        post(uuid(i + 1), { tags: ["ts"] }),
+      ),
+    ]);
+
+    const svc = new BlogService(repo);
+    const result = await svc.getRelatedPostMeta(target);
+
+    expect(result).toHaveLength(6);
+  });
+});

--- a/web/src/features/articles/service.test.ts
+++ b/web/src/features/articles/service.test.ts
@@ -43,7 +43,11 @@ function uuid(n: number): string {
   return `a${hex}b2c3d4-e5f6-7890-abcd-ef1234567890`;
 }
 
-const baseMeta = (u: string, tags: string[] = [], lang: Lang = "ja"): PostMeta => ({
+const baseMeta = (
+  u: string,
+  tags: string[] = [],
+  lang: Lang = "ja",
+): PostMeta => ({
   uuid: u,
   title: "t",
   description: "",

--- a/web/src/features/articles/utils/pager.test.ts
+++ b/web/src/features/articles/utils/pager.test.ts
@@ -53,8 +53,16 @@ describe("Pager", () => {
 
     it("sorts posts by created_at when specified", () => {
       const items = [
-        makeMeta("a1b2c3d4-e5f6-7890-abcd-ef1234567891", "2024-01-01", "2020-01-01"),
-        makeMeta("a1b2c3d4-e5f6-7890-abcd-ef1234567892", "2024-01-01", "2022-01-01"),
+        makeMeta(
+          "a1b2c3d4-e5f6-7890-abcd-ef1234567891",
+          "2024-01-01",
+          "2020-01-01",
+        ),
+        makeMeta(
+          "a1b2c3d4-e5f6-7890-abcd-ef1234567892",
+          "2024-01-01",
+          "2022-01-01",
+        ),
       ];
       const sorted = Pager.sortPost(items, "created_at");
       expect(sorted[0].created_at).toBe("2022-01-01");

--- a/web/src/features/articles/utils/pager.test.ts
+++ b/web/src/features/articles/utils/pager.test.ts
@@ -1,0 +1,121 @@
+import type { PostMeta } from "common";
+import { describe, expect, it } from "vitest";
+
+import pager, { Pager, range } from "./pager";
+
+function makeMeta(
+  uuid: string,
+  updated_at: string,
+  created_at = updated_at,
+): PostMeta {
+  return {
+    uuid,
+    title: `post-${uuid}`,
+    description: "",
+    category: "techblog",
+    tags: [],
+    lang: "ja",
+    created_at,
+    updated_at,
+  };
+}
+
+describe("range", () => {
+  it("returns [1..stop]", () => {
+    expect(range(3)).toEqual([1, 2, 3]);
+  });
+
+  it("returns empty array when stop is 0", () => {
+    expect(range(0)).toEqual([]);
+  });
+});
+
+describe("Pager", () => {
+  const metas: PostMeta[] = [
+    makeMeta("a1b2c3d4-e5f6-7890-abcd-ef1234567890", "2024-01-01"),
+    makeMeta("a2b2c3d4-e5f6-7890-abcd-ef1234567890", "2024-03-01"),
+    makeMeta("a3b2c3d4-e5f6-7890-abcd-ef1234567890", "2024-02-01"),
+    makeMeta("a4b2c3d4-e5f6-7890-abcd-ef1234567890", "2024-05-01"),
+    makeMeta("a5b2c3d4-e5f6-7890-abcd-ef1234567890", "2024-04-01"),
+  ];
+
+  describe("sortPost", () => {
+    it("sorts posts by updated_at descending by default", () => {
+      const sorted = Pager.sortPost([...metas]);
+      expect(sorted.map((p) => p.updated_at)).toEqual([
+        "2024-05-01",
+        "2024-04-01",
+        "2024-03-01",
+        "2024-02-01",
+        "2024-01-01",
+      ]);
+    });
+
+    it("sorts posts by created_at when specified", () => {
+      const items = [
+        makeMeta("a1b2c3d4-e5f6-7890-abcd-ef1234567891", "2024-01-01", "2020-01-01"),
+        makeMeta("a1b2c3d4-e5f6-7890-abcd-ef1234567892", "2024-01-01", "2022-01-01"),
+      ];
+      const sorted = Pager.sortPost(items, "created_at");
+      expect(sorted[0].created_at).toBe("2022-01-01");
+    });
+  });
+
+  describe("getTotalPage", () => {
+    it("rounds up", () => {
+      const p = new Pager(2);
+      expect(p.getTotalPage(new Array(5).fill(0))).toBe(3);
+    });
+
+    it("returns 0 for empty", () => {
+      const p = new Pager(10);
+      expect(p.getTotalPage([])).toBe(0);
+    });
+
+    it("returns exact when evenly divisible", () => {
+      const p = new Pager(2);
+      expect(p.getTotalPage(new Array(4).fill(0))).toBe(2);
+    });
+  });
+
+  describe("getPages", () => {
+    it("returns range of page numbers", () => {
+      const p = new Pager(2);
+      expect(p.getPages(metas)).toEqual([1, 2, 3]);
+    });
+  });
+
+  describe("getPageInformation", () => {
+    it("returns first page with sorted slice", () => {
+      const p = new Pager(2);
+      const info = p.getPageInformation([...metas], 1);
+      expect(info.curPage).toBe(1);
+      expect(info.pages).toEqual([1, 2, 3]);
+      expect(info.pagePostMetas.map((m) => m.updated_at)).toEqual([
+        "2024-05-01",
+        "2024-04-01",
+      ]);
+    });
+
+    it("returns last page which may be partial", () => {
+      const p = new Pager(2);
+      const info = p.getPageInformation([...metas], 3);
+      expect(info.pagePostMetas.map((m) => m.updated_at)).toEqual([
+        "2024-01-01",
+      ]);
+    });
+
+    it("returns empty slice for out-of-range page", () => {
+      const p = new Pager(2);
+      const info = p.getPageInformation([...metas], 99);
+      expect(info.pagePostMetas).toEqual([]);
+      expect(info.curPage).toBe(99);
+    });
+  });
+
+  describe("default export", () => {
+    it("uses count_per_page 10", () => {
+      expect(pager.count_per_page).toBe(10);
+    });
+  });
+});

--- a/web/src/lib/i18n/getDictionary.test.ts
+++ b/web/src/lib/i18n/getDictionary.test.ts
@@ -4,8 +4,8 @@ import {
   defaultLocale,
   isLocale,
   localeToLang,
-  locales,
   localeToOgLocale,
+  locales,
 } from "./config";
 import { getDictionary } from "./getDictionary";
 

--- a/web/src/lib/i18n/getDictionary.test.ts
+++ b/web/src/lib/i18n/getDictionary.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  defaultLocale,
+  isLocale,
+  localeToLang,
+  locales,
+  localeToOgLocale,
+} from "./config";
+import { getDictionary } from "./getDictionary";
+
+describe("i18n/config", () => {
+  it("locales contains ja, en, es", () => {
+    expect(locales).toEqual(["ja", "en", "es"]);
+  });
+
+  it("defaultLocale is ja", () => {
+    expect(defaultLocale).toBe("ja");
+  });
+
+  describe("isLocale", () => {
+    it("returns true for supported locales", () => {
+      expect(isLocale("ja")).toBe(true);
+      expect(isLocale("en")).toBe(true);
+      expect(isLocale("es")).toBe(true);
+    });
+
+    it("returns false for unsupported values", () => {
+      expect(isLocale("fr")).toBe(false);
+      expect(isLocale("")).toBe(false);
+    });
+  });
+
+  describe("localeToLang", () => {
+    it.each([
+      ["ja", "ja"],
+      ["en", "en"],
+      ["es", "es"],
+    ] as const)("maps %s -> %s", (loc, lang) => {
+      expect(localeToLang(loc)).toBe(lang);
+    });
+  });
+
+  it("localeToOgLocale covers every locale", () => {
+    for (const loc of locales) {
+      expect(localeToOgLocale[loc]).toMatch(/^[a-z]{2}_[A-Z]{2}$/);
+    }
+  });
+});
+
+describe("getDictionary", () => {
+  it("loads the ja dictionary", async () => {
+    const dict = await getDictionary("ja");
+    expect(dict).toBeDefined();
+    expect(typeof dict).toBe("object");
+  });
+
+  it("loads the en dictionary", async () => {
+    const dict = await getDictionary("en");
+    expect(dict).toBeDefined();
+    expect(typeof dict).toBe("object");
+  });
+
+  it("loads the es dictionary", async () => {
+    const dict = await getDictionary("es");
+    expect(dict).toBeDefined();
+    expect(typeof dict).toBe("object");
+  });
+
+  it("returns distinct objects for distinct locales", async () => {
+    const [ja, en] = await Promise.all([
+      getDictionary("ja"),
+      getDictionary("en"),
+    ]);
+    // They should be the same shape but not the same reference content-wise.
+    expect(ja).not.toBe(en);
+  });
+});

--- a/web/vitest.config.ts
+++ b/web/vitest.config.ts
@@ -11,6 +11,14 @@ export default defineConfig({
       provider: "v8",
       reporter: ["text", "json", "json-summary", "html"],
       reportsDirectory: "./coverage",
+      include: ["src/**/*.{ts,tsx}"],
+      exclude: [
+        "**/*.test.*",
+        "**/*.d.ts",
+        "src/styled-system/**",
+        "src/test-setup.ts",
+        "src/icons/**",
+      ],
     },
   },
   resolve: {


### PR DESCRIPTION
The writeMdFile test wrote directly to the committed assets/output/test.md
fixture, causing a dirty working tree after every test run. Vitest was also
discovering the stale compiled test under dist/, running it twice against the
same path. Switch the test to a per-run os.tmpdir() directory and exclude
dist/ from vitest test discovery and coverage so the source tree is no longer
touched.