### PR TITLE
Fix profile page citations by removing unsupported Crossref select param

### DIFF
--- a/cli/src/orcid.test.ts
+++ b/cli/src/orcid.test.ts
@@ -1,0 +1,57 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { fetchCitationCount } from "./orcid";
+
+describe("fetchCitationCount", () => {
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it("requests Crossref without the unsupported `select` parameter", async () => {
+    // Regression: Crossref's /works/{doi} endpoint returns HTTP 400 when the
+    // `select` query parameter is supplied, so we must not include it.
+    const calls: string[] = [];
+    const fetchMock = vi.fn(async (input: unknown) => {
+      calls.push(String(input));
+      return new Response(
+        JSON.stringify({ message: { "is-referenced-by-count": 42 } }),
+        { status: 200 },
+      );
+    });
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const count = await fetchCitationCount("10.1093/pcp/pcaf159");
+
+    expect(count).toBe(42);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const calledUrl = calls[0];
+    expect(calledUrl).toContain(
+      "https://api.crossref.org/works/10.1093%2Fpcp%2Fpcaf159",
+    );
+    expect(calledUrl).not.toContain("select");
+  });
+
+  it("returns undefined and does not throw when Crossref responds with an error", async () => {
+    globalThis.fetch = vi.fn(
+      async () => new Response("bad request", { status: 400 }),
+    ) as unknown as typeof fetch;
+
+    const count = await fetchCitationCount("10.1093/pcp/pcaf159");
+    expect(count).toBeUndefined();
+  });
+
+  it("returns undefined when fetch throws", async () => {
+    globalThis.fetch = vi.fn(async () => {
+      throw new Error("network down");
+    }) as unknown as typeof fetch;
+
+    const count = await fetchCitationCount("10.1093/pcp/pcaf159");
+    expect(count).toBeUndefined();
+  });
+});

--- a/cli/src/orcid.ts
+++ b/cli/src/orcid.ts
@@ -139,8 +139,12 @@ function selectPreferredSummary(
   return nonPreprint ?? summaries[0];
 }
 
-async function fetchCitationCount(doi: string): Promise<number | undefined> {
-  const url = `https://api.crossref.org/works/${encodeURIComponent(doi)}?mailto=illumination.k.contact@gmail.com&select=DOI,is-referenced-by-count`;
+export async function fetchCitationCount(
+  doi: string,
+): Promise<number | undefined> {
+  // NOTE: Crossref's /works/{doi} route does not support the `select` query
+  // parameter (it returns HTTP 400). Request the full record instead.
+  const url = `https://api.crossref.org/works/${encodeURIComponent(doi)}?mailto=illumination.k.contact@gmail.com`;
   try {
     const res = await fetch(url, {
       headers: {

--- a/web/src/data/metrics-history.ndjson
+++ b/web/src/data/metrics-history.ndjson
@@ -16,3 +16,4 @@
 {"date":"2026-04-10","sha":"a4b29d6","pr":152,"coverage":{"lines":55.63,"statements":55.67,"functions":45.78,"branches":58.08},"mutation":{"score":42.53,"killed":975,"survived":1320,"timeout":2,"noCoverage":0,"total":2297}}
 {"date":"2026-04-11","sha":"3aa6d11","pr":158,"coverage":{"lines":57.58,"statements":57.54,"functions":47.07,"branches":60.34},"mutation":{"score":45.93,"killed":1131,"survived":1334,"timeout":2,"noCoverage":0,"total":2467}}
 {"date":"2026-04-12","sha":"371a96e","pr":159,"coverage":{"lines":54.66,"statements":54.51,"functions":44.25,"branches":53.46},"mutation":{"score":44.04,"killed":1155,"survived":1470,"timeout":2,"noCoverage":0,"total":2627}}
+{"date":"2026-04-13","sha":"a017b92","pr":161,"coverage":{"lines":55.36,"statements":55.17,"functions":44.5,"branches":53.73},"mutation":{"score":44.27,"killed":1161,"survived":1464,"timeout":2,"noCoverage":0,"total":2627}}


### PR DESCRIPTION
Crossref's /works/{doi} endpoint rejects the `select` query parameter
with HTTP 400 (parameter-not-allowed), so fetchCitationCount always
returned undefined and citations never rendered on the profile page.
Request the full record instead and add a regression test.