### PR TITLE
Add profile link on home and move social links to profile page

### DIFF
--- a/cli/src/orcid.test.ts
+++ b/cli/src/orcid.test.ts
@@ -5,6 +5,7 @@ import {
   dedupeWorksByTitle,
   fetchCitationCount,
   fetchCrossrefWorkMetadata,
+  fetchOwnerNames,
   titleSimilarity,
 } from "./orcid";
 
@@ -154,6 +155,61 @@ describe("fetchCrossrefWorkMetadata", () => {
 
     const metadata = await fetchCrossrefWorkMetadata("10.1/z");
     expect(metadata).toEqual({});
+  });
+});
+
+describe("fetchOwnerNames", () => {
+  const originalFetch = globalThis.fetch;
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it("derives display-name aliases from the ORCID person record", async () => {
+    globalThis.fetch = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            name: {
+              "given-names": { value: "Shogo" },
+              "family-name": { value: "Kawamura" },
+              "credit-name": null,
+            },
+            "other-names": { "other-name": [] },
+          }),
+          { status: 200 },
+        ),
+    ) as unknown as typeof fetch;
+
+    const aliases = await fetchOwnerNames("0000-0002-3066-2940");
+    // Both Western "Given Family" and East Asian "Family Given" forms are
+    // emitted so display-name matching works regardless of byline order.
+    expect(aliases).toContain("Shogo Kawamura");
+    expect(aliases).toContain("Kawamura Shogo");
+  });
+
+  it("includes the credit name and other-name aliases", async () => {
+    globalThis.fetch = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            name: {
+              "given-names": { value: "Jane" },
+              "family-name": { value: "Doe" },
+              "credit-name": { value: "Jane Q. Doe" },
+            },
+            "other-names": {
+              "other-name": [{ content: "J. Doe" }, { content: "Jane Doe" }],
+            },
+          }),
+          { status: 200 },
+        ),
+    ) as unknown as typeof fetch;
+
+    const aliases = await fetchOwnerNames("0000-0000-0000-0000");
+    expect(aliases).toEqual(
+      expect.arrayContaining(["Jane Doe", "Doe Jane", "Jane Q. Doe", "J. Doe"]),
+    );
   });
 });
 

--- a/cli/src/orcid.test.ts
+++ b/cli/src/orcid.test.ts
@@ -4,6 +4,7 @@ import {
   TITLE_SIMILARITY_THRESHOLD,
   dedupeWorksByTitle,
   fetchCitationCount,
+  fetchCrossrefWorkMetadata,
   titleSimilarity,
 } from "./orcid";
 
@@ -58,6 +59,101 @@ describe("fetchCitationCount", () => {
 
     const count = await fetchCitationCount("10.1093/pcp/pcaf159");
     expect(count).toBeUndefined();
+  });
+});
+
+describe("fetchCrossrefWorkMetadata", () => {
+  const originalFetch = globalThis.fetch;
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it("extracts citation count and authors from the same response", async () => {
+    globalThis.fetch = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            message: {
+              "is-referenced-by-count": 7,
+              author: [
+                {
+                  given: "Shogo",
+                  family: "Kawamura",
+                  ORCID: "https://orcid.org/0000-0002-3066-2940",
+                  sequence: "first",
+                },
+                {
+                  given: "Facundo",
+                  family: "Romani",
+                  ORCID: "http://orcid.org/0000-0003-3954-6740",
+                  sequence: "additional",
+                },
+              ],
+            },
+          }),
+          { status: 200 },
+        ),
+    ) as unknown as typeof fetch;
+
+    const metadata = await fetchCrossrefWorkMetadata("10.1093/pcp/pcac129");
+
+    expect(metadata.citationCount).toBe(7);
+    expect(metadata.authors).toEqual([
+      { name: "Shogo Kawamura", orcid: "0000-0002-3066-2940" },
+      { name: "Facundo Romani", orcid: "0000-0003-3954-6740" },
+    ]);
+  });
+
+  it("orders the first author ahead of additional authors", async () => {
+    // Crossref usually returns sorted, but the metadata extractor should
+    // be defensive about ordering so the lead author is always rendered
+    // first.
+    globalThis.fetch = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            message: {
+              author: [
+                { given: "B", family: "Two", sequence: "additional" },
+                { given: "A", family: "One", sequence: "first" },
+              ],
+            },
+          }),
+          { status: 200 },
+        ),
+    ) as unknown as typeof fetch;
+
+    const metadata = await fetchCrossrefWorkMetadata("10.1/x");
+    expect(metadata.authors?.map((a) => a.name)).toEqual(["A One", "B Two"]);
+  });
+
+  it("falls back to the bare `name` field for corporate authors", async () => {
+    globalThis.fetch = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            message: {
+              author: [{ name: "The HUGO Gene Nomenclature Committee" }],
+            },
+          }),
+          { status: 200 },
+        ),
+    ) as unknown as typeof fetch;
+
+    const metadata = await fetchCrossrefWorkMetadata("10.1/y");
+    expect(metadata.authors).toEqual([
+      { name: "The HUGO Gene Nomenclature Committee", orcid: undefined },
+    ]);
+  });
+
+  it("returns an empty object when Crossref errors out", async () => {
+    globalThis.fetch = vi.fn(
+      async () => new Response("nope", { status: 500 }),
+    ) as unknown as typeof fetch;
+
+    const metadata = await fetchCrossrefWorkMetadata("10.1/z");
+    expect(metadata).toEqual({});
   });
 });
 

--- a/cli/src/orcid.test.ts
+++ b/cli/src/orcid.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { fetchCitationCount } from "./orcid";
+import { dedupeWorksByTitle, fetchCitationCount } from "./orcid";
 
 describe("fetchCitationCount", () => {
   const originalFetch = globalThis.fetch;
@@ -53,5 +53,94 @@ describe("fetchCitationCount", () => {
 
     const count = await fetchCitationCount("10.1093/pcp/pcaf159");
     expect(count).toBeUndefined();
+  });
+});
+
+describe("dedupeWorksByTitle", () => {
+  it("collapses preprint and published versions sharing a normalized title", () => {
+    // Regression: ORCID groups duplicates by external-id, so a bioRxiv
+    // preprint and the corresponding journal publication land in separate
+    // groups and both leak into the profile. Title-based dedup should keep
+    // only the published (non-preprint) version.
+    const result = dedupeWorksByTitle([
+      {
+        title:
+          "MarpolBase Expression: A Web-Based, Comprehensive Platform for Visualization and Analysis of Transcriptomes in the Liverwort Marchantia polymorpha",
+        doi: "10.1093/pcp/pcac129",
+        type: "journal-article",
+        publicationYear: 2022,
+      },
+      {
+        title:
+          "MarpolBase Expression: A Web-based, Comprehensive Platform for Visualization and Analysis of Transcriptomes in the Liverwort Marchantia polymorpha",
+        doi: "10.1101/2022.06.03.494633",
+        type: "preprint",
+        publicationYear: 2022,
+      },
+    ]);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]?.doi).toBe("10.1093/pcp/pcac129");
+    expect(result[0]?.type).toBe("journal-article");
+  });
+
+  it("prefers the published version regardless of input order", () => {
+    const result = dedupeWorksByTitle([
+      {
+        title: "Example paper",
+        doi: "10.1101/2024.01.01.000001",
+        type: "preprint",
+      },
+      {
+        title: "Example paper",
+        doi: "10.1234/example",
+        type: "journal-article",
+      },
+    ]);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]?.doi).toBe("10.1234/example");
+  });
+
+  it("keeps the preprint when no published version exists", () => {
+    const result = dedupeWorksByTitle([
+      {
+        title: "Solo preprint",
+        doi: "10.1101/2024.02.02.000002",
+        type: "preprint",
+      },
+    ]);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]?.type).toBe("preprint");
+  });
+
+  it("ignores HTML tags and whitespace differences when matching titles", () => {
+    const result = dedupeWorksByTitle([
+      {
+        title:
+          "Diminished Auxin Signaling Triggers Cellular Reprogramming in <i>Marchantia polymorpha</i>",
+        doi: "10.1093/pcp/pcac004",
+        type: "journal-article",
+      },
+      {
+        title:
+          "Diminished Auxin Signaling Triggers Cellular Reprogramming in Marchantia polymorpha",
+        doi: "10.1101/duplicate",
+        type: "preprint",
+      },
+    ]);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]?.doi).toBe("10.1093/pcp/pcac004");
+  });
+
+  it("keeps distinct works with different titles", () => {
+    const result = dedupeWorksByTitle([
+      { title: "Paper A", doi: "10.1/a", type: "journal-article" },
+      { title: "Paper B", doi: "10.1/b", type: "journal-article" },
+    ]);
+
+    expect(result).toHaveLength(2);
   });
 });

--- a/cli/src/orcid.test.ts
+++ b/cli/src/orcid.test.ts
@@ -1,6 +1,11 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { dedupeWorksByTitle, fetchCitationCount } from "./orcid";
+import {
+  TITLE_SIMILARITY_THRESHOLD,
+  dedupeWorksByTitle,
+  fetchCitationCount,
+  titleSimilarity,
+} from "./orcid";
 
 describe("fetchCitationCount", () => {
   const originalFetch = globalThis.fetch;
@@ -142,5 +147,85 @@ describe("dedupeWorksByTitle", () => {
     ]);
 
     expect(result).toHaveLength(2);
+  });
+
+  it("fuzzy-matches titles with a few added or dropped words", () => {
+    // A retitled preprint that gained a couple of words during peer review
+    // should still be merged with the published version.
+    const result = dedupeWorksByTitle([
+      {
+        title:
+          "MarpolBase Expression: A Web-Based Comprehensive Platform for Visualization and Analysis of Transcriptomes in Marchantia polymorpha",
+        doi: "10.1093/pcp/pcac129",
+        type: "journal-article",
+      },
+      {
+        title:
+          "MarpolBase Expression: A Web-Based Platform for Visualization and Analysis of Transcriptomes in Marchantia polymorpha",
+        doi: "10.1101/preprint",
+        type: "preprint",
+      },
+    ]);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]?.doi).toBe("10.1093/pcp/pcac129");
+  });
+
+  it("does not merge two papers that merely share common keywords", () => {
+    // Two distinct Marchantia papers should not be collapsed even though
+    // they share many domain-specific tokens.
+    const result = dedupeWorksByTitle([
+      {
+        title:
+          "Identification of the sex-determining factor in the liverwort Marchantia polymorpha",
+        doi: "10.1/a",
+        type: "journal-article",
+      },
+      {
+        title:
+          "Diminished Auxin Signaling Triggers Cellular Reprogramming in the Liverwort Marchantia polymorpha",
+        doi: "10.1/b",
+        type: "journal-article",
+      },
+    ]);
+
+    expect(result).toHaveLength(2);
+  });
+});
+
+describe("titleSimilarity", () => {
+  it("returns 1 for titles that differ only in case and punctuation", () => {
+    expect(
+      titleSimilarity(
+        "MarpolBase Expression: A Web-Based Platform",
+        "marpolbase expression a web based platform",
+      ),
+    ).toBe(1);
+  });
+
+  it("strips HTML tags before tokenization", () => {
+    expect(
+      titleSimilarity(
+        "Diminished Auxin Signaling in <i>Marchantia polymorpha</i>",
+        "Diminished Auxin Signaling in Marchantia polymorpha",
+      ),
+    ).toBe(1);
+  });
+
+  it("crosses the dedupe threshold for near-identical titles", () => {
+    const sim = titleSimilarity(
+      "MarpolBase Expression: A Web-Based Comprehensive Platform for Marchantia",
+      "MarpolBase Expression: A Web-Based Platform for Marchantia",
+    );
+    expect(sim).toBeGreaterThanOrEqual(TITLE_SIMILARITY_THRESHOLD);
+  });
+
+  it("stays below the threshold for unrelated titles", () => {
+    expect(
+      titleSimilarity(
+        "Identification of the sex-determining factor in Marchantia polymorpha",
+        "Diminished Auxin Signaling Triggers Cellular Reprogramming",
+      ),
+    ).toBeLessThan(TITLE_SIMILARITY_THRESHOLD);
   });
 });

--- a/cli/src/orcid.ts
+++ b/cli/src/orcid.ts
@@ -3,6 +3,7 @@ import type {
   ProfileEducation,
   ProfileEmployment,
   ProfileWork,
+  ProfileWorkAuthor,
 } from "common/profile";
 import { logger } from "./logger";
 
@@ -205,9 +206,63 @@ export function dedupeWorksByTitle(works: ProfileWork[]): ProfileWork[] {
   return result.map((entry) => entry.work);
 }
 
-export async function fetchCitationCount(
+interface CrossrefAuthor {
+  given?: string;
+  family?: string;
+  name?: string;
+  ORCID?: string;
+  sequence?: string;
+}
+
+export interface CrossrefWorkMetadata {
+  citationCount?: number;
+  authors?: ProfileWorkAuthor[];
+}
+
+function formatCrossrefAuthorName(author: CrossrefAuthor): string | undefined {
+  // Crossref normally splits names into `given` / `family`, but corporate
+  // authors (and a few human ones) come through as a single `name` field.
+  const given = author.given?.trim();
+  const family = author.family?.trim();
+  if (given && family) return `${given} ${family}`;
+  if (family) return family;
+  if (given) return given;
+  return author.name?.trim() || undefined;
+}
+
+function normalizeCrossrefOrcid(raw: string | undefined): string | undefined {
+  if (!raw) return undefined;
+  // Crossref returns ORCIDs as full URLs (http(s)://orcid.org/0000-...);
+  // strip the prefix so consumers get a bare identifier.
+  return raw.replace(/^https?:\/\/orcid\.org\//, "");
+}
+
+function parseCrossrefAuthors(
+  raw: CrossrefAuthor[] | undefined,
+): ProfileWorkAuthor[] | undefined {
+  if (!raw || raw.length === 0) return undefined;
+  // Sort by `sequence`: "first" comes before "additional" so the lead author
+  // is always rendered first regardless of API ordering quirks.
+  const sorted = [...raw].sort((a, b) => {
+    const aFirst = a.sequence === "first" ? 0 : 1;
+    const bFirst = b.sequence === "first" ? 0 : 1;
+    return aFirst - bFirst;
+  });
+  const authors: ProfileWorkAuthor[] = [];
+  for (const author of sorted) {
+    const name = formatCrossrefAuthorName(author);
+    if (!name) continue;
+    authors.push({
+      name,
+      orcid: normalizeCrossrefOrcid(author.ORCID),
+    });
+  }
+  return authors.length > 0 ? authors : undefined;
+}
+
+export async function fetchCrossrefWorkMetadata(
   doi: string,
-): Promise<number | undefined> {
+): Promise<CrossrefWorkMetadata> {
   // NOTE: Crossref's /works/{doi} route does not support the `select` query
   // parameter (it returns HTTP 400). Request the full record instead.
   const url = `https://api.crossref.org/works/${encodeURIComponent(doi)}?mailto=illumination.k.contact@gmail.com`;
@@ -220,16 +275,33 @@ export async function fetchCitationCount(
     });
     if (!res.ok) {
       logger.warn({ doi, status: res.status }, "Crossref API request failed");
-      return undefined;
+      return {};
     }
     const data = (await res.json()) as {
-      message: { "is-referenced-by-count"?: number };
+      message: {
+        "is-referenced-by-count"?: number;
+        author?: CrossrefAuthor[];
+      };
     };
-    return data.message["is-referenced-by-count"];
+    return {
+      citationCount: data.message["is-referenced-by-count"],
+      authors: parseCrossrefAuthors(data.message.author),
+    };
   } catch (err) {
-    logger.warn({ doi, err }, "Failed to fetch citation count from Crossref");
-    return undefined;
+    logger.warn({ doi, err }, "Failed to fetch metadata from Crossref");
+    return {};
   }
+}
+
+/**
+ * Backwards-compatible wrapper around {@link fetchCrossrefWorkMetadata} that
+ * only returns the citation count.
+ */
+export async function fetchCitationCount(
+  doi: string,
+): Promise<number | undefined> {
+  const { citationCount } = await fetchCrossrefWorkMetadata(doi);
+  return citationCount;
 }
 
 export async function fetchWorks(orcidId: string): Promise<ProfileWork[]> {
@@ -260,18 +332,21 @@ export async function fetchWorks(orcidId: string): Promise<ProfileWork[]> {
 
   const works = dedupeWorksByTitle(collected);
 
-  // Fetch citation counts from Crossref for works with DOIs
+  // Fetch citation counts and authors from Crossref for works with DOIs
   const worksWithDoi = works.filter((w) => w.doi);
   if (worksWithDoi.length > 0) {
     logger.info(
       { count: worksWithDoi.length },
-      "Fetching citation counts from Crossref",
+      "Fetching work metadata from Crossref",
     );
     // Process sequentially with small batches to respect rate limits
     for (const work of worksWithDoi) {
-      if (work.doi) {
-        work.citationCount = await fetchCitationCount(work.doi);
-      }
+      if (!work.doi) continue;
+      const { citationCount, authors } = await fetchCrossrefWorkMetadata(
+        work.doi,
+      );
+      work.citationCount = citationCount;
+      work.authors = authors;
     }
   }
 

--- a/cli/src/orcid.ts
+++ b/cli/src/orcid.ts
@@ -139,6 +139,35 @@ function selectPreferredSummary(
   return nonPreprint ?? summaries[0];
 }
 
+function normalizeTitleKey(title: string): string {
+  return title
+    .replace(/<[^>]+>/g, "") // strip HTML tags like <i>
+    .replace(/\s+/g, " ")
+    .trim()
+    .toLowerCase();
+}
+
+export function dedupeWorksByTitle(works: ProfileWork[]): ProfileWork[] {
+  // ORCID groups duplicates by external-id, but a preprint and its published
+  // version often have different DOIs and end up in separate groups. Collapse
+  // them here by normalized title, preferring the non-preprint version.
+  const byKey = new Map<string, ProfileWork>();
+  for (const work of works) {
+    const key = normalizeTitleKey(work.title);
+    const existing = byKey.get(key);
+    if (!existing) {
+      byKey.set(key, work);
+      continue;
+    }
+    const existingIsPreprint = existing.type === "preprint";
+    const candidateIsPreprint = work.type === "preprint";
+    if (existingIsPreprint && !candidateIsPreprint) {
+      byKey.set(key, work);
+    }
+  }
+  return Array.from(byKey.values());
+}
+
 export async function fetchCitationCount(
   doi: string,
 ): Promise<number | undefined> {
@@ -171,7 +200,7 @@ export async function fetchWorks(orcidId: string): Promise<ProfileWork[]> {
     group: OrcidWorkGroup[];
   };
 
-  const works: ProfileWork[] = [];
+  const collected: ProfileWork[] = [];
 
   for (const group of data.group) {
     const summary = selectPreferredSummary(group["work-summary"] ?? []);
@@ -180,7 +209,7 @@ export async function fetchWorks(orcidId: string): Promise<ProfileWork[]> {
     const externalIds = summary["external-ids"]?.["external-id"] ?? [];
     const doiId = externalIds.find((id) => id["external-id-type"] === "doi");
 
-    works.push({
+    collected.push({
       title: summary.title.title.value,
       journalTitle: summary["journal-title"]?.value ?? undefined,
       publicationYear: summary["publication-date"]?.year?.value
@@ -191,6 +220,8 @@ export async function fetchWorks(orcidId: string): Promise<ProfileWork[]> {
       type: summary.type ?? undefined,
     });
   }
+
+  const works = dedupeWorksByTitle(collected);
 
   // Fetch citation counts from Crossref for works with DOIs
   const worksWithDoi = works.filter((w) => w.doi);

--- a/cli/src/orcid.ts
+++ b/cli/src/orcid.ts
@@ -114,6 +114,41 @@ function parseAffiliations(
   return results;
 }
 
+interface OrcidPersonName {
+  "given-names"?: { value: string } | null;
+  "family-name"?: { value: string } | null;
+  "credit-name"?: { value: string } | null;
+}
+
+interface OrcidPerson {
+  name?: OrcidPersonName | null;
+  "other-names"?: {
+    "other-name"?: Array<{ content?: string | null }> | null;
+  } | null;
+}
+
+export async function fetchOwnerNames(orcidId: string): Promise<string[]> {
+  // Build a list of name aliases from the ORCID person record so that
+  // contributors without a linked ORCID id can still be matched against the
+  // owner by display name.
+  const data = (await fetchOrcidJson(orcidId, "person")) as OrcidPerson;
+  const aliases = new Set<string>();
+  const name = data.name;
+  if (name) {
+    const given = name["given-names"]?.value?.trim();
+    const family = name["family-name"]?.value?.trim();
+    const credit = name["credit-name"]?.value?.trim();
+    if (given && family) aliases.add(`${given} ${family}`);
+    if (family && given) aliases.add(`${family} ${given}`);
+    if (credit) aliases.add(credit);
+  }
+  for (const other of data["other-names"]?.["other-name"] ?? []) {
+    const value = other.content?.trim();
+    if (value) aliases.add(value);
+  }
+  return Array.from(aliases);
+}
+
 export async function fetchEmployments(
   orcidId: string,
 ): Promise<ProfileEmployment[]> {
@@ -358,7 +393,8 @@ export async function fetchWorks(orcidId: string): Promise<ProfileWork[]> {
 export async function fetchOrcidProfile(orcidId: string): Promise<ProfileDump> {
   logger.info({ orcidId }, "Fetching ORCID profile");
 
-  const [employments, educations, works] = await Promise.all([
+  const [ownerNames, employments, educations, works] = await Promise.all([
+    fetchOwnerNames(orcidId),
     fetchEmployments(orcidId),
     fetchEducations(orcidId),
     fetchWorks(orcidId),
@@ -366,6 +402,7 @@ export async function fetchOrcidProfile(orcidId: string): Promise<ProfileDump> {
 
   logger.info(
     {
+      ownerNames: ownerNames.length,
       employments: employments.length,
       educations: educations.length,
       works: works.length,
@@ -376,6 +413,7 @@ export async function fetchOrcidProfile(orcidId: string): Promise<ProfileDump> {
   return {
     orcidId,
     fetchedAt: new Date().toISOString(),
+    ownerNames,
     employments,
     educations,
     works,

--- a/cli/src/orcid.ts
+++ b/cli/src/orcid.ts
@@ -139,33 +139,70 @@ function selectPreferredSummary(
   return nonPreprint ?? summaries[0];
 }
 
-function normalizeTitleKey(title: string): string {
-  return title
-    .replace(/<[^>]+>/g, "") // strip HTML tags like <i>
-    .replace(/\s+/g, " ")
-    .trim()
-    .toLowerCase();
+// Threshold for Jaccard similarity above which two titles are treated as
+// the same work. 0.85 tolerates minor word-level edits (a few changed,
+// added, or dropped tokens out of ~20) without merging genuinely distinct
+// papers that happen to share common nouns like "Marchantia polymorpha".
+export const TITLE_SIMILARITY_THRESHOLD = 0.85;
+
+function tokenizeTitle(title: string): Set<string> {
+  return new Set(
+    title
+      .replace(/<[^>]+>/g, " ") // strip HTML tags like <i>
+      .toLowerCase()
+      .split(/[^\p{L}\p{N}]+/u)
+      .filter((token) => token.length > 0),
+  );
+}
+
+function jaccardSimilarity(a: Set<string>, b: Set<string>): number {
+  if (a.size === 0 && b.size === 0) return 1;
+  let intersection = 0;
+  for (const token of a) {
+    if (b.has(token)) intersection++;
+  }
+  const union = a.size + b.size - intersection;
+  return union === 0 ? 0 : intersection / union;
+}
+
+export function titleSimilarity(a: string, b: string): number {
+  return jaccardSimilarity(tokenizeTitle(a), tokenizeTitle(b));
 }
 
 export function dedupeWorksByTitle(works: ProfileWork[]): ProfileWork[] {
   // ORCID groups duplicates by external-id, but a preprint and its published
   // version often have different DOIs and end up in separate groups. Collapse
-  // them here by normalized title, preferring the non-preprint version.
-  const byKey = new Map<string, ProfileWork>();
+  // them here by fuzzy title matching, preferring the non-preprint version.
+  type Entry = { work: ProfileWork; tokens: Set<string> };
+  const result: Entry[] = [];
+
   for (const work of works) {
-    const key = normalizeTitleKey(work.title);
-    const existing = byKey.get(key);
-    if (!existing) {
-      byKey.set(key, work);
+    const tokens = tokenizeTitle(work.title);
+    let matchedIdx = -1;
+    for (let i = 0; i < result.length; i++) {
+      const existing = result[i];
+      if (!existing) continue;
+      if (
+        jaccardSimilarity(tokens, existing.tokens) >= TITLE_SIMILARITY_THRESHOLD
+      ) {
+        matchedIdx = i;
+        break;
+      }
+    }
+    if (matchedIdx === -1) {
+      result.push({ work, tokens });
       continue;
     }
-    const existingIsPreprint = existing.type === "preprint";
+    const existing = result[matchedIdx];
+    if (!existing) continue;
+    const existingIsPreprint = existing.work.type === "preprint";
     const candidateIsPreprint = work.type === "preprint";
     if (existingIsPreprint && !candidateIsPreprint) {
-      byKey.set(key, work);
+      result[matchedIdx] = { work, tokens };
     }
   }
-  return Array.from(byKey.values());
+
+  return result.map((entry) => entry.work);
 }
 
 export async function fetchCitationCount(

--- a/packages/common/profile.ts
+++ b/packages/common/profile.ts
@@ -20,6 +20,13 @@ export const profileEducationSchema = z.object({
 
 export type ProfileEducation = z.infer<typeof profileEducationSchema>;
 
+export const profileWorkAuthorSchema = z.object({
+  name: z.string(),
+  orcid: z.string().optional(),
+});
+
+export type ProfileWorkAuthor = z.infer<typeof profileWorkAuthorSchema>;
+
 export const profileWorkSchema = z.object({
   title: z.string(),
   journalTitle: z.string().optional(),
@@ -28,6 +35,7 @@ export const profileWorkSchema = z.object({
   url: z.string().optional(),
   type: z.string().optional(),
   citationCount: z.number().optional(),
+  authors: z.array(profileWorkAuthorSchema).optional(),
 });
 
 export type ProfileWork = z.infer<typeof profileWorkSchema>;

--- a/packages/common/profile.ts
+++ b/packages/common/profile.ts
@@ -43,6 +43,7 @@ export type ProfileWork = z.infer<typeof profileWorkSchema>;
 export const profileDumpSchema = z.object({
   orcidId: z.string(),
   fetchedAt: z.string(),
+  ownerNames: z.array(z.string()).default([]),
   employments: z.array(profileEmploymentSchema),
   educations: z.array(profileEducationSchema),
   works: z.array(profileWorkSchema),

--- a/web/src/app/[locale]/page.tsx
+++ b/web/src/app/[locale]/page.tsx
@@ -3,13 +3,13 @@ import Link from "next/link";
 
 import { css, cx } from "@/styled-system/css";
 
-import { BookOpenIcon, DocumentTextIcon } from "@heroicons/react/24/outline";
+import {
+  BookOpenIcon,
+  DocumentTextIcon,
+  UserIcon,
+} from "@heroicons/react/24/outline";
 import type { Route } from "next";
 
-import GithubIcon from "@/icons/GithubIcon";
-import LinkedInIcon from "@/icons/LinkedInIcon";
-import OrcidIcon from "@/icons/OrcidIcon";
-import TwitterIcon from "@/icons/TwitterIcon";
 import { type Locale, getDictionary, isLocale } from "@/lib/i18n";
 
 const caveat = Caveat({ subsets: ["latin"] });
@@ -88,91 +88,35 @@ export default async function Home({
           })}
         />
 
-        {/* Social Links */}
-        <div
+        {/* Profile Link */}
+        <Link
+          href={`/${locale}/profile` as Route}
           className={css({
-            display: "flex",
-            gap: 5,
+            display: "inline-flex",
             alignItems: "center",
+            gap: 2,
+            px: 5,
+            py: 2.5,
+            rounded: "full",
+            bg: "bg.surface",
+            borderWidth: 1,
+            borderColor: "border.default",
+            color: "text.secondary",
+            fontSize: "sm",
+            fontWeight: "medium",
+            transition: "all",
+            transitionDuration: "normal",
             animation: "fadeInUp 0.6s ease-out 0.2s both",
+            _hover: {
+              borderColor: "accent.primary",
+              color: "accent.primary",
+              transform: "translateY(-1px)",
+            },
           })}
         >
-          <a
-            href="https://www.github.com/illumination-k"
-            aria-label="GitHub"
-            className={css({
-              display: "flex",
-              alignItems: "center",
-              gap: 2,
-              color: "text.secondary",
-              fontSize: "sm",
-              transition: "colors",
-              transitionDuration: "fast",
-              _hover: { color: "accent.primary" },
-            })}
-          >
-            <GithubIcon aria-hidden="true" className={css({ h: 5, w: 5 })} />
-            <span>GitHub</span>
-          </a>
-          <a
-            href="https://twitter.com/illuminationK"
-            aria-label="Twitter"
-            className={css({
-              display: "flex",
-              alignItems: "center",
-              gap: 2,
-              color: "text.secondary",
-              fontSize: "sm",
-              transition: "colors",
-              transitionDuration: "fast",
-              _hover: { color: "accent.primary" },
-            })}
-          >
-            <TwitterIcon
-              aria-hidden="true"
-              className={css({ h: 5, w: 5, fill: "currentColor" })}
-            />
-            <span>Twitter</span>
-          </a>
-          <a
-            href="https://orcid.org/0000-0002-3066-2940"
-            aria-label="ORCID"
-            target="_blank"
-            rel="noopener noreferrer"
-            className={css({
-              display: "flex",
-              alignItems: "center",
-              gap: 2,
-              color: "text.secondary",
-              fontSize: "sm",
-              transition: "colors",
-              transitionDuration: "fast",
-              _hover: { color: "accent.primary" },
-            })}
-          >
-            <OrcidIcon aria-hidden="true" className={css({ h: 5, w: 5 })} />
-            <span>ORCID</span>
-          </a>
-          <a
-            href="https://www.linkedin.com/in/shogo-kawamura-77492b223"
-            aria-label="LinkedIn"
-            target="_blank"
-            rel="noopener noreferrer"
-            className={css({
-              display: "flex",
-              alignItems: "center",
-              gap: 2,
-              color: "text.secondary",
-              fontSize: "sm",
-              transition: "colors",
-              transitionDuration: "fast",
-              _hover: { color: "accent.primary" },
-            })}
-          >
-            <LinkedInIcon aria-hidden="true" className={css({ h: 5, w: 5 })} />
-            <span>LinkedIn</span>
-          </a>
-        </div>
+          <UserIcon aria-hidden="true" className={css({ h: 4, w: 4 })} />
+          <span>{dict.home.profile}</span>
+        </Link>
 
         {/* Content Cards */}
         <div

--- a/web/src/app/[locale]/profile/page.tsx
+++ b/web/src/app/[locale]/profile/page.tsx
@@ -214,7 +214,7 @@ export default async function ProfilePage({ params }: Props) {
       {profile.works.length > 0 && (
         <section className={sectionStyle}>
           <h2 className={sectionHeadingStyle}>{dict.profile.publications}</h2>
-          <WorkList works={profile.works} />
+          <WorkList works={profile.works} ownOrcidId={profile.orcidId} />
         </section>
       )}
 

--- a/web/src/app/[locale]/profile/page.tsx
+++ b/web/src/app/[locale]/profile/page.tsx
@@ -6,7 +6,10 @@ import { EducationList } from "@/features/profile/components/EducationList";
 import { EmploymentList } from "@/features/profile/components/EmploymentList";
 import { WorkList } from "@/features/profile/components/WorkList";
 import { profileRepository } from "@/features/profile/constants";
+import GithubIcon from "@/icons/GithubIcon";
+import LinkedInIcon from "@/icons/LinkedInIcon";
 import OrcidIcon from "@/icons/OrcidIcon";
+import TwitterIcon from "@/icons/TwitterIcon";
 import { type Locale, getDictionary, isLocale } from "@/lib/i18n";
 
 interface Props {
@@ -92,7 +95,7 @@ export default async function ProfilePage({ params }: Props) {
         className={css({
           display: "flex",
           justifyContent: "center",
-          mb: { base: 8, md: 10 },
+          mb: { base: 4, md: 5 },
         })}
       >
         <a
@@ -110,6 +113,78 @@ export default async function ProfilePage({ params }: Props) {
         >
           <OrcidIcon aria-hidden="true" className={css({ h: 4, w: 4 })} />
           ORCID: {profile.orcidId}
+        </a>
+      </div>
+
+      {/* Social Links */}
+      <div
+        className={css({
+          display: "flex",
+          justifyContent: "center",
+          gap: 5,
+          alignItems: "center",
+          mb: { base: 8, md: 10 },
+        })}
+      >
+        <a
+          href="https://www.github.com/illumination-k"
+          aria-label="GitHub"
+          target="_blank"
+          rel="noopener noreferrer"
+          className={css({
+            display: "flex",
+            alignItems: "center",
+            gap: 1.5,
+            color: "text.secondary",
+            fontSize: "sm",
+            transition: "colors",
+            transitionDuration: "fast",
+            _hover: { color: "accent.primary" },
+          })}
+        >
+          <GithubIcon aria-hidden="true" className={css({ h: 5, w: 5 })} />
+          <span>GitHub</span>
+        </a>
+        <a
+          href="https://twitter.com/illuminationK"
+          aria-label="Twitter"
+          target="_blank"
+          rel="noopener noreferrer"
+          className={css({
+            display: "flex",
+            alignItems: "center",
+            gap: 1.5,
+            color: "text.secondary",
+            fontSize: "sm",
+            transition: "colors",
+            transitionDuration: "fast",
+            _hover: { color: "accent.primary" },
+          })}
+        >
+          <TwitterIcon
+            aria-hidden="true"
+            className={css({ h: 5, w: 5, fill: "currentColor" })}
+          />
+          <span>Twitter</span>
+        </a>
+        <a
+          href="https://www.linkedin.com/in/shogo-kawamura-77492b223"
+          aria-label="LinkedIn"
+          target="_blank"
+          rel="noopener noreferrer"
+          className={css({
+            display: "flex",
+            alignItems: "center",
+            gap: 1.5,
+            color: "text.secondary",
+            fontSize: "sm",
+            transition: "colors",
+            transitionDuration: "fast",
+            _hover: { color: "accent.primary" },
+          })}
+        >
+          <LinkedInIcon aria-hidden="true" className={css({ h: 5, w: 5 })} />
+          <span>LinkedIn</span>
         </a>
       </div>
 

--- a/web/src/app/[locale]/profile/page.tsx
+++ b/web/src/app/[locale]/profile/page.tsx
@@ -214,7 +214,11 @@ export default async function ProfilePage({ params }: Props) {
       {profile.works.length > 0 && (
         <section className={sectionStyle}>
           <h2 className={sectionHeadingStyle}>{dict.profile.publications}</h2>
-          <WorkList works={profile.works} ownOrcidId={profile.orcidId} />
+          <WorkList
+            works={profile.works}
+            ownOrcidId={profile.orcidId}
+            ownerNames={profile.ownerNames}
+          />
         </section>
       )}
 

--- a/web/src/components/Nav.tsx
+++ b/web/src/components/Nav.tsx
@@ -2,13 +2,11 @@ import { Caveat } from "next/font/google";
 import Link from "next/link";
 
 import { css, cx } from "@/styled-system/css";
-import { circle } from "@/styled-system/patterns";
 
 import { HomeIcon } from "@heroicons/react/24/solid";
 import type { Route } from "next";
 
 import GithubIcon from "@/icons/GithubIcon";
-import TwitterIcon from "@/icons/TwitterIcon";
 import type { Locale } from "@/lib/i18n";
 import { getDictionary } from "@/lib/i18n";
 
@@ -83,17 +81,6 @@ export default async function Nav({ locale }: { locale: Locale }) {
         >
           {dict.nav.techBlog}
         </Link>
-
-        <a
-          href="https://twitter.com/illuminationK"
-          className={circle({ size: 8, bg: "bg.elevated" })}
-          aria-label="twitter"
-        >
-          <TwitterIcon
-            aria-hidden="true"
-            className={css({ h: 8, w: 8, fill: "accent.primary" })}
-          />
-        </a>
 
         <a
           href="https://www.github.com/illumination-k"

--- a/web/src/data/metrics-history.ndjson
+++ b/web/src/data/metrics-history.ndjson
@@ -17,4 +17,4 @@
 {"date":"2026-04-11","sha":"3aa6d11","pr":158,"coverage":{"lines":57.58,"statements":57.54,"functions":47.07,"branches":60.34},"mutation":{"score":45.93,"killed":1131,"survived":1334,"timeout":2,"noCoverage":0,"total":2467}}
 {"date":"2026-04-12","sha":"371a96e","pr":159,"coverage":{"lines":54.66,"statements":54.51,"functions":44.25,"branches":53.46},"mutation":{"score":44.04,"killed":1155,"survived":1470,"timeout":2,"noCoverage":0,"total":2627}}
 {"date":"2026-04-13","sha":"a017b92","pr":161,"coverage":{"lines":55.36,"statements":55.17,"functions":44.5,"branches":53.73},"mutation":{"score":44.27,"killed":1161,"survived":1464,"timeout":2,"noCoverage":0,"total":2627}}
-{"date":"2026-04-13","sha":"305dcdf","pr":162,"coverage":{"lines":56.6,"statements":56.27,"functions":45.87,"branches":54.29},"mutation":{"score":45.76,"killed":1258,"survived":1496,"timeout":4,"noCoverage":0,"total":2758}}
+{"date":"2026-04-13","sha":"aef9c9e","pr":162,"coverage":{"lines":57.14,"statements":56.88,"functions":46.14,"branches":54.3},"mutation":{"score":45.78,"killed":1275,"survived":1515,"timeout":4,"noCoverage":0,"total":2794}}

--- a/web/src/data/metrics-history.ndjson
+++ b/web/src/data/metrics-history.ndjson
@@ -17,3 +17,4 @@
 {"date":"2026-04-11","sha":"3aa6d11","pr":158,"coverage":{"lines":57.58,"statements":57.54,"functions":47.07,"branches":60.34},"mutation":{"score":45.93,"killed":1131,"survived":1334,"timeout":2,"noCoverage":0,"total":2467}}
 {"date":"2026-04-12","sha":"371a96e","pr":159,"coverage":{"lines":54.66,"statements":54.51,"functions":44.25,"branches":53.46},"mutation":{"score":44.04,"killed":1155,"survived":1470,"timeout":2,"noCoverage":0,"total":2627}}
 {"date":"2026-04-13","sha":"a017b92","pr":161,"coverage":{"lines":55.36,"statements":55.17,"functions":44.5,"branches":53.73},"mutation":{"score":44.27,"killed":1161,"survived":1464,"timeout":2,"noCoverage":0,"total":2627}}
+{"date":"2026-04-13","sha":"2ebeb13","pr":162,"coverage":{"lines":55.36,"statements":55.17,"functions":44.5,"branches":53.73},"mutation":{"score":44.27,"killed":1161,"survived":1464,"timeout":2,"noCoverage":0,"total":2627}}

--- a/web/src/data/metrics-history.ndjson
+++ b/web/src/data/metrics-history.ndjson
@@ -17,4 +17,4 @@
 {"date":"2026-04-11","sha":"3aa6d11","pr":158,"coverage":{"lines":57.58,"statements":57.54,"functions":47.07,"branches":60.34},"mutation":{"score":45.93,"killed":1131,"survived":1334,"timeout":2,"noCoverage":0,"total":2467}}
 {"date":"2026-04-12","sha":"371a96e","pr":159,"coverage":{"lines":54.66,"statements":54.51,"functions":44.25,"branches":53.46},"mutation":{"score":44.04,"killed":1155,"survived":1470,"timeout":2,"noCoverage":0,"total":2627}}
 {"date":"2026-04-13","sha":"a017b92","pr":161,"coverage":{"lines":55.36,"statements":55.17,"functions":44.5,"branches":53.73},"mutation":{"score":44.27,"killed":1161,"survived":1464,"timeout":2,"noCoverage":0,"total":2627}}
-{"date":"2026-04-13","sha":"2ebeb13","pr":162,"coverage":{"lines":55.36,"statements":55.17,"functions":44.5,"branches":53.73},"mutation":{"score":44.27,"killed":1161,"survived":1464,"timeout":2,"noCoverage":0,"total":2627}}
+{"date":"2026-04-13","sha":"979e615","pr":162,"coverage":{"lines":55.7,"statements":55.49,"functions":44.78,"branches":54.1},"mutation":{"score":44.56,"killed":1181,"survived":1472,"timeout":2,"noCoverage":0,"total":2655}}

--- a/web/src/data/metrics-history.ndjson
+++ b/web/src/data/metrics-history.ndjson
@@ -17,4 +17,4 @@
 {"date":"2026-04-11","sha":"3aa6d11","pr":158,"coverage":{"lines":57.58,"statements":57.54,"functions":47.07,"branches":60.34},"mutation":{"score":45.93,"killed":1131,"survived":1334,"timeout":2,"noCoverage":0,"total":2467}}
 {"date":"2026-04-12","sha":"371a96e","pr":159,"coverage":{"lines":54.66,"statements":54.51,"functions":44.25,"branches":53.46},"mutation":{"score":44.04,"killed":1155,"survived":1470,"timeout":2,"noCoverage":0,"total":2627}}
 {"date":"2026-04-13","sha":"a017b92","pr":161,"coverage":{"lines":55.36,"statements":55.17,"functions":44.5,"branches":53.73},"mutation":{"score":44.27,"killed":1161,"survived":1464,"timeout":2,"noCoverage":0,"total":2627}}
-{"date":"2026-04-13","sha":"979e615","pr":162,"coverage":{"lines":55.7,"statements":55.49,"functions":44.78,"branches":54.1},"mutation":{"score":44.56,"killed":1181,"survived":1472,"timeout":2,"noCoverage":0,"total":2655}}
+{"date":"2026-04-13","sha":"d60afc3","pr":162,"coverage":{"lines":56.17,"statements":55.92,"functions":45.32,"branches":54.29},"mutation":{"score":45.15,"killed":1216,"survived":1482,"timeout":4,"noCoverage":0,"total":2702}}

--- a/web/src/data/metrics-history.ndjson
+++ b/web/src/data/metrics-history.ndjson
@@ -17,4 +17,4 @@
 {"date":"2026-04-11","sha":"3aa6d11","pr":158,"coverage":{"lines":57.58,"statements":57.54,"functions":47.07,"branches":60.34},"mutation":{"score":45.93,"killed":1131,"survived":1334,"timeout":2,"noCoverage":0,"total":2467}}
 {"date":"2026-04-12","sha":"371a96e","pr":159,"coverage":{"lines":54.66,"statements":54.51,"functions":44.25,"branches":53.46},"mutation":{"score":44.04,"killed":1155,"survived":1470,"timeout":2,"noCoverage":0,"total":2627}}
 {"date":"2026-04-13","sha":"a017b92","pr":161,"coverage":{"lines":55.36,"statements":55.17,"functions":44.5,"branches":53.73},"mutation":{"score":44.27,"killed":1161,"survived":1464,"timeout":2,"noCoverage":0,"total":2627}}
-{"date":"2026-04-13","sha":"d60afc3","pr":162,"coverage":{"lines":56.17,"statements":55.92,"functions":45.32,"branches":54.29},"mutation":{"score":45.15,"killed":1216,"survived":1482,"timeout":4,"noCoverage":0,"total":2702}}
+{"date":"2026-04-13","sha":"305dcdf","pr":162,"coverage":{"lines":56.6,"statements":56.27,"functions":45.87,"branches":54.29},"mutation":{"score":45.76,"killed":1258,"survived":1496,"timeout":4,"noCoverage":0,"total":2758}}

--- a/web/src/features/profile/components/WorkList.tsx
+++ b/web/src/features/profile/components/WorkList.tsx
@@ -7,9 +7,15 @@ import type { ProfileWork } from "common/profile";
 interface Props {
   works: ProfileWork[];
   ownOrcidId?: string;
+  ownerNames?: string[];
 }
 
-export function WorkList({ works, ownOrcidId }: Props) {
+function normalizeName(name: string): string {
+  return name.toLowerCase().replace(/\s+/g, " ").trim();
+}
+
+export function WorkList({ works, ownOrcidId, ownerNames }: Props) {
+  const ownNameSet = new Set((ownerNames ?? []).map(normalizeName));
   return (
     <ul className={css({ listStyle: "none", p: 0, m: 0 })}>
       {works.map((work) => (
@@ -92,8 +98,12 @@ export function WorkList({ works, ownOrcidId }: Props) {
               })}
             >
               {work.authors.map((author, idx) => {
-                const isOwn =
+                const matchesOrcid =
                   ownOrcidId !== undefined && author.orcid === ownOrcidId;
+                const matchesName =
+                  author.orcid === undefined &&
+                  ownNameSet.has(normalizeName(author.name));
+                const isOwn = matchesOrcid || matchesName;
                 return (
                   <Fragment key={`${author.orcid ?? author.name}-${idx}`}>
                     {idx > 0 && ", "}

--- a/web/src/features/profile/components/WorkList.tsx
+++ b/web/src/features/profile/components/WorkList.tsx
@@ -1,12 +1,15 @@
+import { Fragment } from "react";
+
 import { css } from "@/styled-system/css";
 
 import type { ProfileWork } from "common/profile";
 
 interface Props {
   works: ProfileWork[];
+  ownOrcidId?: string;
 }
 
-export function WorkList({ works }: Props) {
+export function WorkList({ works, ownOrcidId }: Props) {
   return (
     <ul className={css({ listStyle: "none", p: 0, m: 0 })}>
       {works.map((work) => (
@@ -79,6 +82,38 @@ export function WorkList({ works }: Props) {
               </span>
             )}
           </div>
+          {work.authors && work.authors.length > 0 && (
+            <p
+              className={css({
+                fontSize: "xs",
+                color: "text.secondary",
+                mt: 1,
+                lineHeight: "1.6",
+              })}
+            >
+              {work.authors.map((author, idx) => {
+                const isOwn =
+                  ownOrcidId !== undefined && author.orcid === ownOrcidId;
+                return (
+                  <Fragment key={`${author.orcid ?? author.name}-${idx}`}>
+                    {idx > 0 && ", "}
+                    <span
+                      className={
+                        isOwn
+                          ? css({
+                              fontWeight: "bold",
+                              color: "text.primary",
+                            })
+                          : undefined
+                      }
+                    >
+                      {author.name}
+                    </span>
+                  </Fragment>
+                );
+              })}
+            </p>
+          )}
           {work.journalTitle && (
             <p
               className={css({

--- a/web/src/lib/i18n/dictionaries/en.ts
+++ b/web/src/lib/i18n/dictionaries/en.ts
@@ -7,6 +7,7 @@ const en: Dictionary = {
     techBlogSub: "Technical articles",
     paperStream: "Paper Stream",
     paperStreamSub: "Paper notes",
+    profile: "Profile",
   },
   nav: {
     techBlog: "TechBlog",

--- a/web/src/lib/i18n/dictionaries/es.ts
+++ b/web/src/lib/i18n/dictionaries/es.ts
@@ -7,6 +7,7 @@ const es: Dictionary = {
     techBlogSub: "Artículos técnicos",
     paperStream: "Paper Stream",
     paperStreamSub: "Notas de artículos",
+    profile: "Perfil",
   },
   nav: {
     techBlog: "TechBlog",

--- a/web/src/lib/i18n/dictionaries/ja.ts
+++ b/web/src/lib/i18n/dictionaries/ja.ts
@@ -8,6 +8,7 @@ const ja: Dictionary = {
     techBlogSub: "技術ブログ",
     paperStream: "Paper Stream",
     paperStreamSub: "論文メモ",
+    profile: "プロフィール",
   },
   // Navigation
   nav: {

--- a/web/src/lib/i18n/types.ts
+++ b/web/src/lib/i18n/types.ts
@@ -10,6 +10,7 @@ export interface Dictionary {
     techBlogSub: string;
     paperStream: string;
     paperStreamSub: string;
+    profile: string;
   };
   nav: {
     techBlog: string;


### PR DESCRIPTION
Replace the social link row on the home page with a single Profile entry
point, relocate the social links (GitHub/Twitter/LinkedIn) onto the
profile page next to ORCID, and drop the Twitter icon from the header
nav.