### PR TITLE
Fix sitemap coverage and per-locale consistency

### DIFF
--- a/cli/src/feed.test.ts
+++ b/cli/src/feed.test.ts
@@ -7,12 +7,16 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import generateFeed from "./feed";
 
+const UUID_FIRST = "a1b2c3d4-e5f6-7890-abcd-ef1234567890";
+const UUID_SECOND = "a2b2c3d4-e5f6-7890-abcd-ef1234567890";
+const UUID_EN_ONLY = "a3b2c3d4-e5f6-7890-abcd-ef1234567890";
+
 function makeDump(): Dump {
   return {
     posts: [
       {
         meta: {
-          uuid: "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+          uuid: UUID_FIRST,
           title: "First Post",
           description: "A first post",
           category: "techblog",
@@ -25,9 +29,26 @@ function makeDump(): Dump {
         compiledMarkdown: "<h1>First</h1>",
         headings: [{ depth: 1, value: "First" }],
       },
+      // English translation of the first post — must be deduped away in
+      // favour of the ja primary version.
       {
         meta: {
-          uuid: "a2b2c3d4-e5f6-7890-abcd-ef1234567890",
+          uuid: UUID_FIRST,
+          title: "First Post (EN)",
+          description: "A first post (en)",
+          category: "techblog",
+          tags: ["ts"],
+          lang: "en",
+          created_at: "2024-01-01",
+          updated_at: "2024-02-15",
+        },
+        rawMarkdown: "# First",
+        compiledMarkdown: "<h1>First</h1>",
+        headings: [{ depth: 1, value: "First" }],
+      },
+      {
+        meta: {
+          uuid: UUID_SECOND,
           title: "Second Post",
           description: "A second post",
           category: "techblog",
@@ -39,6 +60,22 @@ function makeDump(): Dump {
         rawMarkdown: "# Second",
         compiledMarkdown: "<h1>Second</h1>",
         headings: [{ depth: 1, value: "Second" }],
+      },
+      // English-only post — must appear in the feed with an /en/ URL.
+      {
+        meta: {
+          uuid: UUID_EN_ONLY,
+          title: "English Only Post",
+          description: "An english-only post",
+          category: "techblog",
+          tags: [],
+          lang: "en",
+          created_at: "2024-05-01",
+          updated_at: "2024-05-10",
+        },
+        rawMarkdown: "# English",
+        compiledMarkdown: "<h1>English</h1>",
+        headings: [{ depth: 1, value: "English" }],
       },
     ],
     categories: ["techblog"],
@@ -62,7 +99,7 @@ describe("generateFeed", () => {
     rmSync(workDir, { recursive: true, force: true });
   });
 
-  it("writes feed.xml, atom.xml, feed.json containing all posts", async () => {
+  it("writes feed.xml, atom.xml, feed.json containing one item per unique post", async () => {
     await generateFeed(dumpPath, dst);
 
     const rss = readFileSync(path.join(dst, "feed.xml"), "utf-8");
@@ -72,14 +109,67 @@ describe("generateFeed", () => {
     for (const body of [rss, atom, json]) {
       expect(body).toContain("First Post");
       expect(body).toContain("Second Post");
-      expect(body).toContain(
-        "techblog/post/a1b2c3d4-e5f6-7890-abcd-ef1234567890",
-      );
+      expect(body).toContain("English Only Post");
     }
 
-    // feed.json should be valid JSON
+    // feed.json should be valid JSON and deduped by UUID (3 posts, one of
+    // which has a ja+en pair that collapses to a single item).
     const parsed = JSON.parse(json);
-    expect(parsed.items).toHaveLength(2);
+    expect(parsed.items).toHaveLength(3);
+  });
+
+  it("prefers the primary language (ja) when a post exists in multiple languages", async () => {
+    await generateFeed(dumpPath, dst);
+    const json = JSON.parse(readFileSync(path.join(dst, "feed.json"), "utf-8"));
+
+    const firstItem = json.items.find((item: { id: string }) =>
+      item.id.endsWith(`/techblog/post/${UUID_FIRST}`),
+    );
+    expect(firstItem).toBeDefined();
+    // The English translation must not be emitted separately.
+    expect(firstItem.title).toBe("First Post");
+    expect(firstItem.url).toBe(
+      `https://www.illumination-k.dev/ja/techblog/post/${UUID_FIRST}`,
+    );
+  });
+
+  it("emits locale-prefixed URLs that match each post's language", async () => {
+    await generateFeed(dumpPath, dst);
+    const json = JSON.parse(readFileSync(path.join(dst, "feed.json"), "utf-8"));
+    const urls: string[] = json.items.map(
+      (item: { url: string }) => item.url,
+    );
+
+    expect(urls).toContain(
+      `https://www.illumination-k.dev/ja/techblog/post/${UUID_FIRST}`,
+    );
+    expect(urls).toContain(
+      `https://www.illumination-k.dev/ja/techblog/post/${UUID_SECOND}`,
+    );
+    // English-only post keeps its /en/ prefix.
+    expect(urls).toContain(
+      `https://www.illumination-k.dev/en/techblog/post/${UUID_EN_ONLY}`,
+    );
+
+    // No item should link to an unprefixed /techblog/post/... URL.
+    for (const u of urls) {
+      expect(u).not.toMatch(
+        /https:\/\/www\.illumination-k\.dev\/techblog\/post\//,
+      );
+    }
+  });
+
+  it("orders items by updated_at descending", async () => {
+    await generateFeed(dumpPath, dst);
+    const json = JSON.parse(readFileSync(path.join(dst, "feed.json"), "utf-8"));
+    const ids: string[] = json.items.map((item: { id: string }) => item.id);
+
+    // English-only (2024-05-10) → Second (2024-04-01) → First (2024-02-01)
+    expect(ids).toEqual([
+      `https://www.illumination-k.dev/en/techblog/post/${UUID_EN_ONLY}`,
+      `https://www.illumination-k.dev/ja/techblog/post/${UUID_SECOND}`,
+      `https://www.illumination-k.dev/ja/techblog/post/${UUID_FIRST}`,
+    ]);
   });
 
   it("creates destination directory if it does not exist", async () => {

--- a/cli/src/feed.ts
+++ b/cli/src/feed.ts
@@ -3,10 +3,30 @@ import { type Author, Feed } from "feed";
 
 import path from "node:path";
 import { promisify } from "node:util";
+import type { DumpPost, Lang } from "common";
 import { readDump } from "common/io";
 
 const writeFileAsync = promisify(fs.writeFile);
 const mkdirAsync = promisify(fs.mkdir);
+
+// Primary language wins when a post exists in multiple languages. Falls
+// back through the list so every post appears exactly once in the feed.
+const LANG_PRIORITY: Record<Lang, number> = { ja: 0, en: 1, es: 2 };
+
+function pickPrimaryVersions(posts: DumpPost[]): DumpPost[] {
+  const byUuid = new Map<string, DumpPost>();
+  for (const post of posts) {
+    const existing = byUuid.get(post.meta.uuid);
+    if (
+      !existing ||
+      LANG_PRIORITY[post.meta.lang] < LANG_PRIORITY[existing.meta.lang]
+    ) {
+      byUuid.set(post.meta.uuid, post);
+    }
+  }
+  return Array.from(byUuid.values());
+}
+
 export default async function generateFeed(dumpPath: PathLike, dst: PathLike) {
   const dump = await readDump(dumpPath);
   const url = "https://www.illumination-k.dev";
@@ -33,10 +53,14 @@ export default async function generateFeed(dumpPath: PathLike, dst: PathLike) {
     },
   });
 
-  const posts = dump.posts;
+  const posts = pickPrimaryVersions(dump.posts).sort(
+    (a, b) =>
+      new Date(b.meta.updated_at).getTime() -
+      new Date(a.meta.updated_at).getTime(),
+  );
 
   for (const post of posts) {
-    const postUrl = `${url}/techblog/post/${post.meta.uuid}`;
+    const postUrl = `${url}/${post.meta.lang}/techblog/post/${post.meta.uuid}`;
     feed.addItem({
       title: post.meta.title,
       description: post.meta.description,

--- a/web/public/robots.txt
+++ b/web/public/robots.txt
@@ -1,6 +1,9 @@
 # *
 User-agent: *
 Allow: /
+Disallow: /ja/search
+Disallow: /en/search
+Disallow: /es/search
 
 # Host
 Host: https://www.illumination-k.dev

--- a/web/src/app/[locale]/(articles)/_factory/tagFactory.tsx
+++ b/web/src/app/[locale]/(articles)/_factory/tagFactory.tsx
@@ -72,19 +72,20 @@ export class TagPagerFactory {
       const tags = await this.blogService.repo.tags();
 
       const nestedParams = await Promise.all(
-        [...tags].map(async (tag) => {
-          const tagged_posts = await this.blogService.repo.filterPosts(
-            undefined,
-            tag,
-          );
-          const totalPage = pager.getTotalPage(tagged_posts);
-          return locales.flatMap((locale) =>
-            Array.from({ length: totalPage }, (_, i) => ({
+        locales.flatMap((locale) => {
+          const lang = localeToLang(locale);
+          return [...tags].map(async (tag) => {
+            const tagged_posts = await this.blogService.repo.filterPosts(
+              lang,
+              tag,
+            );
+            const totalPage = pager.getTotalPage(tagged_posts);
+            return Array.from({ length: totalPage }, (_, i) => ({
               locale,
               tag,
               page: String(i + 1),
-            })),
-          );
+            }));
+          });
         }),
       );
 

--- a/web/src/app/sitemap.test.ts
+++ b/web/src/app/sitemap.test.ts
@@ -148,7 +148,12 @@ describe("sitemap", () => {
     const urls = new Set(entries.map((e) => e.url));
 
     for (const locale of ["ja", "en", "es"]) {
-      for (const path of ["disclaimer", "privacy-policy", "profile", "metrics"]) {
+      for (const path of [
+        "disclaimer",
+        "privacy-policy",
+        "profile",
+        "metrics",
+      ]) {
         expect(urls.has(`${BASE}/${locale}/${path}`)).toBe(true);
       }
     }

--- a/web/src/app/sitemap.test.ts
+++ b/web/src/app/sitemap.test.ts
@@ -1,0 +1,245 @@
+import { describe, expect, it, vi } from "vitest";
+
+const shared = vi.hoisted(() => {
+  interface Post {
+    meta: {
+      uuid: string;
+      title: string;
+      description: string;
+      category: string;
+      tags: string[];
+      lang: "ja" | "en" | "es";
+      created_at: string;
+      updated_at: string;
+    };
+    rawMarkdown: string;
+    compiledMarkdown: string;
+    headings: unknown[];
+  }
+
+  interface Dump {
+    posts: Post[];
+    categories: string[];
+    tags: string[];
+  }
+
+  const makePost = (
+    uuid: string,
+    overrides: Partial<Post["meta"]> = {},
+  ): Post => ({
+    meta: {
+      uuid,
+      title: `post-${uuid}`,
+      description: "",
+      category: "techblog",
+      tags: [],
+      lang: "ja",
+      created_at: "2024-01-01",
+      updated_at: "2024-01-01",
+      ...overrides,
+    },
+    rawMarkdown: "",
+    compiledMarkdown: "",
+    headings: [],
+  });
+
+  // 11 ja posts tagged "rust" — more than count_per_page (10) so pagination
+  // produces 2 pages for /ja/techblog and /ja/techblog/tag/rust.
+  const jaRustPosts: Post[] = Array.from({ length: 11 }, (_, i) =>
+    makePost(`TB-JA-RUST-${i + 1}`, {
+      lang: "ja",
+      tags: ["rust"],
+      updated_at: `2024-02-${String(i + 1).padStart(2, "0")}`,
+    }),
+  );
+
+  const TECHBLOG_DUMP: Dump = {
+    posts: [
+      ...jaRustPosts,
+      // en translation of TB-JA-RUST-1 with a newer updated_at — used to
+      // verify lastModified picks the most recent across languages.
+      makePost("TB-JA-RUST-1", {
+        lang: "en",
+        tags: ["rust"],
+        updated_at: "2024-06-01",
+      }),
+      // en-only post (no ja counterpart): must still appear in /ja/.../post.
+      makePost("TB-EN-ONLY", {
+        lang: "en",
+        tags: [],
+        updated_at: "2024-04-01",
+      }),
+      // ja post tagged "go" — used to verify go tag pages appear only for ja.
+      makePost("TB-JA-GO", {
+        lang: "ja",
+        tags: ["go"],
+        updated_at: "2024-03-01",
+      }),
+    ],
+    categories: ["techblog"],
+    tags: ["rust", "go"],
+  };
+
+  const PAPERSTREAM_DUMP: Dump = {
+    posts: [
+      makePost("PS-JA", {
+        lang: "ja",
+        category: "paperstream",
+        updated_at: "2024-05-01",
+      }),
+    ],
+    categories: ["paperstream"],
+    tags: [],
+  };
+
+  const defaultTags = ["archive", "draft"];
+
+  const makeFakeService = (dump: Dump) => ({
+    repo: {
+      list: async () => dump.posts,
+      tags: async () => {
+        const unique = Array.from(new Set(dump.tags));
+        const sorted = unique
+          .filter((t) => !defaultTags.includes(t))
+          .sort((a, b) => a.localeCompare(b));
+        return sorted.concat(defaultTags);
+      },
+      filterPosts: async (lang?: string, tag?: string, category?: string) =>
+        dump.posts.filter((p) => {
+          if (lang && p.meta.lang !== lang) return false;
+          if (tag && !p.meta.tags.includes(tag)) return false;
+          if (category && p.meta.category !== category) return false;
+          return true;
+        }),
+      retrieve: async () => undefined,
+      categories: async () => dump.categories,
+    },
+  });
+
+  return { TECHBLOG_DUMP, PAPERSTREAM_DUMP, makeFakeService };
+});
+
+vi.mock("@/features/techblog/constant", () => ({
+  blogService: shared.makeFakeService(shared.TECHBLOG_DUMP),
+}));
+
+vi.mock("@/features/paperStream/constants", () => ({
+  paperStreamService: shared.makeFakeService(shared.PAPERSTREAM_DUMP),
+}));
+
+// Import after vi.mock is set up.
+import sitemap from "./sitemap";
+
+const BASE = "https://www.illumination-k.dev";
+
+describe("sitemap", () => {
+  it("includes the site root and per-locale homepages", async () => {
+    const entries = await sitemap();
+    const urls = entries.map((e) => e.url);
+
+    expect(urls).toContain(BASE);
+    expect(urls).toContain(`${BASE}/ja`);
+    expect(urls).toContain(`${BASE}/en`);
+    expect(urls).toContain(`${BASE}/es`);
+  });
+
+  it("includes the static policy/profile pages for every locale", async () => {
+    const entries = await sitemap();
+    const urls = new Set(entries.map((e) => e.url));
+
+    for (const locale of ["ja", "en", "es"]) {
+      for (const path of ["disclaimer", "privacy-policy", "profile", "metrics"]) {
+        expect(urls.has(`${BASE}/${locale}/${path}`)).toBe(true);
+      }
+    }
+  });
+
+  it("does not include any /search URL", async () => {
+    const entries = await sitemap();
+    for (const entry of entries) {
+      expect(entry.url).not.toMatch(/\/search(\/|$)/);
+    }
+  });
+
+  it("generates pagination per-locale based on each locale's post count", async () => {
+    const entries = await sitemap();
+    const urls = new Set(entries.map((e) => e.url));
+
+    // ja has 12 posts (11 rust + 1 go) → 2 pages.
+    expect(urls.has(`${BASE}/ja/techblog/1`)).toBe(true);
+    expect(urls.has(`${BASE}/ja/techblog/2`)).toBe(true);
+    expect(urls.has(`${BASE}/ja/techblog/3`)).toBe(false);
+
+    // en has 2 posts → 1 page.
+    expect(urls.has(`${BASE}/en/techblog/1`)).toBe(true);
+    expect(urls.has(`${BASE}/en/techblog/2`)).toBe(false);
+
+    // es has 0 posts → Math.max(1, 0) forces a single page,
+    // matching PagerFactory.createGenerateStaticParamsFn.
+    expect(urls.has(`${BASE}/es/techblog/1`)).toBe(true);
+    expect(urls.has(`${BASE}/es/techblog/2`)).toBe(false);
+
+    // paperStream has 1 ja post → 1 page, plus forced pages for en/es.
+    expect(urls.has(`${BASE}/ja/paperstream/1`)).toBe(true);
+    expect(urls.has(`${BASE}/en/paperstream/1`)).toBe(true);
+    expect(urls.has(`${BASE}/es/paperstream/1`)).toBe(true);
+    expect(urls.has(`${BASE}/ja/paperstream/2`)).toBe(false);
+  });
+
+  it("lists every unique post UUID across all languages for every locale", async () => {
+    const entries = await sitemap();
+    const urls = new Set(entries.map((e) => e.url));
+
+    for (const locale of ["ja", "en", "es"]) {
+      // en-only post is still emitted for all locales.
+      expect(urls.has(`${BASE}/${locale}/techblog/post/TB-EN-ONLY`)).toBe(true);
+      // ja-only post with the "go" tag is also present everywhere.
+      expect(urls.has(`${BASE}/${locale}/techblog/post/TB-JA-GO`)).toBe(true);
+      // Shared post appears once per locale.
+      expect(urls.has(`${BASE}/${locale}/techblog/post/TB-JA-RUST-1`)).toBe(
+        true,
+      );
+    }
+  });
+
+  it("picks the most recent updated_at across languages for lastModified", async () => {
+    const entries = await sitemap();
+    const shared = entries.find(
+      (e) => e.url === `${BASE}/ja/techblog/post/TB-JA-RUST-1`,
+    );
+    expect(shared?.lastModified).toBe("2024-06-01");
+  });
+
+  it("generates tag pagination per-locale and skips locales with no tagged posts", async () => {
+    const entries = await sitemap();
+    const urls = new Set(entries.map((e) => e.url));
+
+    // Tag index pages (one per locale, unconditional).
+    expect(urls.has(`${BASE}/ja/techblog/tag`)).toBe(true);
+    expect(urls.has(`${BASE}/en/techblog/tag`)).toBe(true);
+    expect(urls.has(`${BASE}/es/techblog/tag`)).toBe(true);
+
+    // rust: 11 ja posts → 2 pages for ja, 1 page for en, 0 pages for es.
+    expect(urls.has(`${BASE}/ja/techblog/tag/rust/1`)).toBe(true);
+    expect(urls.has(`${BASE}/ja/techblog/tag/rust/2`)).toBe(true);
+    expect(urls.has(`${BASE}/ja/techblog/tag/rust/3`)).toBe(false);
+    expect(urls.has(`${BASE}/en/techblog/tag/rust/1`)).toBe(true);
+    expect(urls.has(`${BASE}/en/techblog/tag/rust/2`)).toBe(false);
+    expect(urls.has(`${BASE}/es/techblog/tag/rust/1`)).toBe(false);
+
+    // go: only ja has a post → only /ja/.../tag/go/1.
+    expect(urls.has(`${BASE}/ja/techblog/tag/go/1`)).toBe(true);
+    expect(urls.has(`${BASE}/en/techblog/tag/go/1`)).toBe(false);
+    expect(urls.has(`${BASE}/es/techblog/tag/go/1`)).toBe(false);
+
+    // Default tags (archive/draft) have no posts → no per-tag pages.
+    expect(urls.has(`${BASE}/ja/techblog/tag/archive/1`)).toBe(false);
+    expect(urls.has(`${BASE}/ja/techblog/tag/draft/1`)).toBe(false);
+  });
+
+  it("does not emit duplicate URLs", async () => {
+    const entries = await sitemap();
+    const urls = entries.map((e) => e.url);
+    expect(new Set(urls).size).toBe(urls.length);
+  });
+});

--- a/web/src/app/sitemap.ts
+++ b/web/src/app/sitemap.ts
@@ -3,23 +3,34 @@ import type { MetadataRoute } from "next";
 import pager from "@/features/articles/utils/pager";
 import { paperStreamService } from "@/features/paperStream/constants";
 import { blogService } from "@/features/techblog/constant";
-import { locales } from "@/lib/i18n";
+import { localeToLang, locales } from "@/lib/i18n";
 
 export const dynamic = "force-static";
 
 const BASE_URL = "https://www.illumination-k.dev";
 
+const STATIC_PATHS = [
+  "disclaimer",
+  "privacy-policy",
+  "profile",
+  "metrics",
+] as const;
+
 async function generatePaginationSitemap(
   prefix: string,
   service: typeof blogService,
 ): Promise<MetadataRoute.Sitemap> {
-  const posts = await service.repo.filterPosts("ja");
-  const totalPage = pager.getTotalPage(posts);
-  return locales.flatMap((locale) =>
-    Array.from({ length: totalPage }, (_, i) => ({
-      url: `${BASE_URL}/${locale}/${prefix}/${i + 1}`,
-    })),
+  const perLocale = await Promise.all(
+    locales.map(async (locale) => {
+      const lang = localeToLang(locale);
+      const posts = await service.repo.filterPosts(lang);
+      const totalPage = Math.max(1, pager.getTotalPage(posts));
+      return Array.from({ length: totalPage }, (_, i) => ({
+        url: `${BASE_URL}/${locale}/${prefix}/${i + 1}`,
+      }));
+    }),
   );
+  return perLocale.flat();
 }
 
 async function generateTagSitemap(
@@ -31,61 +42,85 @@ async function generateTagSitemap(
     url: `${BASE_URL}/${locale}/${prefix}/tag`,
   }));
 
-  for (const tag of tags) {
-    const taggedPosts = await service.repo.filterPosts("ja", tag);
-    const totalPage = pager.getTotalPage(taggedPosts);
-    for (const locale of locales) {
-      for (let i = 1; i <= totalPage; i++) {
-        entries.push({
-          url: `${BASE_URL}/${locale}/${prefix}/tag/${tag}/${i}`,
-        });
+  // Tag pages are statically generated per-locale via filterPosts(lang, tag)
+  // (see TagPagerFactory.createGenerateStaticParamsFn), so mirror that here
+  // to avoid advertising pages that were not generated.
+  await Promise.all(
+    locales.map(async (locale) => {
+      const lang = localeToLang(locale);
+      for (const tag of tags) {
+        const taggedPosts = await service.repo.filterPosts(lang, tag);
+        const totalPage = pager.getTotalPage(taggedPosts);
+        for (let i = 1; i <= totalPage; i++) {
+          entries.push({
+            url: `${BASE_URL}/${locale}/${prefix}/tag/${tag}/${i}`,
+          });
+        }
       }
-    }
-  }
+    }),
+  );
 
   return entries;
 }
 
+async function generatePostSitemap(
+  prefix: string,
+  service: typeof blogService,
+): Promise<MetadataRoute.Sitemap> {
+  // Post pages are statically generated for every unique UUID × every
+  // locale, regardless of which language the source post is authored in
+  // (see PostPageFactory.createGenerateStaticParamsFn). Mirror that here
+  // so posts that only exist in en/es are also listed.
+  const allPosts = await service.repo.list();
+  const latestByUuid = new Map<string, string>();
+  for (const post of allPosts) {
+    const existing = latestByUuid.get(post.meta.uuid);
+    if (!existing || existing < post.meta.updated_at) {
+      latestByUuid.set(post.meta.uuid, post.meta.updated_at);
+    }
+  }
+
+  return locales.flatMap((locale) =>
+    Array.from(latestByUuid, ([uuid, lastModified]) => ({
+      url: `${BASE_URL}/${locale}/${prefix}/post/${uuid}`,
+      lastModified,
+    })),
+  );
+}
+
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
-  const posts = await blogService.repo.filterPosts("ja");
-  const postSitemap: MetadataRoute.Sitemap = locales.flatMap((locale) =>
-    posts.map((post) => ({
-      url: `${BASE_URL}/${locale}/techblog/post/${post.meta.uuid}`,
-      lastModified: post.meta.updated_at,
-    })),
-  );
-
-  const paperStreamPosts = await paperStreamService.repo.filterPosts("ja");
-  const paperStreamSitemap: MetadataRoute.Sitemap = locales.flatMap((locale) =>
-    paperStreamPosts.map((post) => ({
-      url: `${BASE_URL}/${locale}/paperstream/post/${post.meta.uuid}`,
-      lastModified: post.meta.updated_at,
-    })),
-  );
-
-  const techblogPagination = await generatePaginationSitemap(
-    "techblog",
-    blogService,
-  );
-  const paperStreamPagination = await generatePaginationSitemap(
-    "paperstream",
-    paperStreamService,
-  );
-  const techblogTags = await generateTagSitemap("techblog", blogService);
-  const paperStreamTags = await generateTagSitemap(
-    "paperstream",
-    paperStreamService,
-  );
+  const [
+    techblogPosts,
+    paperStreamPosts,
+    techblogPagination,
+    paperStreamPagination,
+    techblogTags,
+    paperStreamTags,
+  ] = await Promise.all([
+    generatePostSitemap("techblog", blogService),
+    generatePostSitemap("paperstream", paperStreamService),
+    generatePaginationSitemap("techblog", blogService),
+    generatePaginationSitemap("paperstream", paperStreamService),
+    generateTagSitemap("techblog", blogService),
+    generateTagSitemap("paperstream", paperStreamService),
+  ]);
 
   const localeHomepages: MetadataRoute.Sitemap = locales.map((locale) => ({
     url: `${BASE_URL}/${locale}`,
   }));
 
+  const staticPages: MetadataRoute.Sitemap = locales.flatMap((locale) =>
+    STATIC_PATHS.map((path) => ({
+      url: `${BASE_URL}/${locale}/${path}`,
+    })),
+  );
+
   return [
     { url: BASE_URL },
     ...localeHomepages,
-    ...postSitemap,
-    ...paperStreamSitemap,
+    ...staticPages,
+    ...techblogPosts,
+    ...paperStreamPosts,
     ...techblogPagination,
     ...paperStreamPagination,
     ...techblogTags,

--- a/web/src/data/metrics-history.ndjson
+++ b/web/src/data/metrics-history.ndjson
@@ -18,3 +18,4 @@
 {"date":"2026-04-12","sha":"371a96e","pr":159,"coverage":{"lines":54.66,"statements":54.51,"functions":44.25,"branches":53.46},"mutation":{"score":44.04,"killed":1155,"survived":1470,"timeout":2,"noCoverage":0,"total":2627}}
 {"date":"2026-04-13","sha":"a017b92","pr":161,"coverage":{"lines":55.36,"statements":55.17,"functions":44.5,"branches":53.73},"mutation":{"score":44.27,"killed":1161,"survived":1464,"timeout":2,"noCoverage":0,"total":2627}}
 {"date":"2026-04-13","sha":"aef9c9e","pr":162,"coverage":{"lines":57.14,"statements":56.88,"functions":46.14,"branches":54.3},"mutation":{"score":45.78,"killed":1275,"survived":1515,"timeout":4,"noCoverage":0,"total":2794}}
+{"date":"2026-04-13","sha":"6038c30","pr":163,"coverage":{"lines":59.06,"statements":59.02,"functions":49.28,"branches":54.95},"mutation":{"score":46.08,"killed":1290,"survived":1514,"timeout":4,"noCoverage":0,"total":2808}}

--- a/web/src/features/articles/repository/dump.test.ts
+++ b/web/src/features/articles/repository/dump.test.ts
@@ -121,11 +121,33 @@ describe("DumpRepository", () => {
       expect(posts[0].meta.lang).toBe("en");
     });
 
-    it("filters by tag (note: current impl overwrites lang filter)", async () => {
+    it("filters by lang AND tag together", async () => {
       const repo = new DumpRepository(dumpPath);
       const posts = await repo.filterPosts("ja", "ts");
-      // Implementation reassigns `ok`, so the final predicate is the tag check.
-      expect(posts.map((p) => p.meta.uuid).sort()).toEqual([UUID_A, UUID_A]);
+      expect(posts).toHaveLength(1);
+      expect(posts[0].meta.uuid).toBe(UUID_A);
+      expect(posts[0].meta.lang).toBe("ja");
+    });
+
+    it("filters by tag alone when lang is undefined", async () => {
+      const repo = new DumpRepository(dumpPath);
+      const posts = await repo.filterPosts(undefined, "ts");
+      expect(posts.map((p) => p.meta.lang).sort()).toEqual(["en", "ja"]);
+    });
+
+    it("filters by lang AND category together", async () => {
+      const repo = new DumpRepository(dumpPath);
+      const posts = await repo.filterPosts("ja", undefined, "techblog");
+      expect(posts.map((p) => p.meta.uuid).sort()).toEqual(
+        [UUID_A, UUID_C].sort(),
+      );
+    });
+
+    it("filters by lang AND tag AND category together", async () => {
+      const repo = new DumpRepository(dumpPath);
+      const posts = await repo.filterPosts("ja", "ts", "techblog");
+      expect(posts).toHaveLength(1);
+      expect(posts[0].meta.uuid).toBe(UUID_A);
     });
 
     it("filters by category", async () => {

--- a/web/src/features/articles/repository/dump.ts
+++ b/web/src/features/articles/repository/dump.ts
@@ -67,12 +67,10 @@ export default class DumpRepository implements IBlogRepository {
       tag?: string,
       category?: string,
     ) => {
-      let ok = true;
-      if (lang) ok = lang === post.meta.lang;
-      if (tag) ok = post.meta.tags.includes(tag);
-      if (category) ok = category === post.meta.category;
-
-      return ok;
+      if (lang && post.meta.lang !== lang) return false;
+      if (tag && !post.meta.tags.includes(tag)) return false;
+      if (category && post.meta.category !== category) return false;
+      return true;
     };
 
     return dump.posts.filter((post) => checkPost(post, lang, tag, category));


### PR DESCRIPTION
- Compute techblog/paperStream pagination page counts per-locale to match
  PagerFactory's static params, so en/es no longer advertise ja-sized
  pagination that was never generated.
- Emit post sitemap entries for every unique UUID × every locale (matching
  PostPageFactory), so posts only authored in en/es are discoverable.
- lastModified now uses the most recent updated_at across all language
  versions of the same post.
- Generate tag pagination per-locale via filterPosts(lang, tag), and mirror
  that in TagPagerFactory.generateStaticParams so locales without any
  matching posts stop emitting phantom tag pages.
- Fix DumpRepository.filterPosts: conditions were overwriting each other
  with `let ok = ...`; now combines lang/tag/category with AND semantics.
- Add disclaimer / privacy-policy / profile / metrics static pages to the
  sitemap for every locale and keep /search out of both sitemap.xml and
  robots.txt (Disallow).
- Add sitemap.test.ts covering locale homepages, static pages, pagination
  per-locale, post UUID coverage, tag per-locale behavior, lastModified
  selection, /search exclusion, and duplicate-URL check.
- Update dump.test.ts to assert the fixed AND-semantics.