### PR TITLE
Add tests for untested CLI utilities and profile schemas

### DIFF
--- a/cli/src/extractHeader.test.ts
+++ b/cli/src/extractHeader.test.ts
@@ -1,0 +1,112 @@
+import type { Root } from "mdast";
+import remarkParse from "remark-parse";
+import { unified } from "unified";
+import { describe, expect, it } from "vitest";
+
+import extractHeader, { headings } from "./extractHeader";
+
+function parse(markdown: string): Root {
+  return unified().use(remarkParse).parse(markdown) as Root;
+}
+
+describe("headings", () => {
+  it("returns an empty list when the AST has no headings", () => {
+    const ast = parse("Just a paragraph.\n\nAnother paragraph.\n");
+    expect(headings(ast, 3)).toEqual([]);
+  });
+
+  it("collects headings up to the requested depth", () => {
+    const ast = parse(
+      "# H1\n\n## H2\n\n### H3\n\n#### H4\n\n##### H5\n\n###### H6\n",
+    );
+
+    expect(headings(ast, 3)).toEqual([
+      { depth: 1, value: "H1" },
+      { depth: 2, value: "H2" },
+      { depth: 3, value: "H3" },
+    ]);
+  });
+
+  it("filters out headings deeper than the limit", () => {
+    const ast = parse("# Top\n\n## Sub\n\n### Deep\n");
+    expect(headings(ast, 2)).toEqual([
+      { depth: 1, value: "Top" },
+      { depth: 2, value: "Sub" },
+    ]);
+  });
+
+  it("treats depth=1 as 'only top-level headings'", () => {
+    const ast = parse("# Only\n\n## Excluded\n\n### Also Excluded\n");
+    expect(headings(ast, 1)).toEqual([{ depth: 1, value: "Only" }]);
+  });
+
+  it("includes all six heading levels when depth is 6", () => {
+    const ast = parse(
+      "# A\n\n## B\n\n### C\n\n#### D\n\n##### E\n\n###### F\n",
+    );
+    const result = headings(ast, 6);
+    expect(result).toHaveLength(6);
+    expect(result.map((h) => h.depth)).toEqual([1, 2, 3, 4, 5, 6]);
+  });
+
+  it("preserves heading order from the source document", () => {
+    const ast = parse("## First\n\n# Second\n\n## Third\n");
+    expect(headings(ast, 3)).toEqual([
+      { depth: 2, value: "First" },
+      { depth: 1, value: "Second" },
+      { depth: 2, value: "Third" },
+    ]);
+  });
+
+  it("flattens inline markup inside headings to plain text", () => {
+    const ast = parse("# Hello **bold** and `code`\n");
+    expect(headings(ast, 3)).toEqual([
+      { depth: 1, value: "Hello bold and code" },
+    ]);
+  });
+
+  it("excludes image alt text from heading values", () => {
+    const ast = parse("# Title ![alt text](img.png) suffix\n");
+    expect(headings(ast, 3)).toEqual([{ depth: 1, value: "Title  suffix" }]);
+  });
+});
+
+describe("extractHeader compiler", () => {
+  function compile(markdown: string, depth?: number) {
+    const processor = unified().use(remarkParse);
+    // Assigning the compiler bypasses unified's type narrowing, but is the
+    // documented escape hatch for plugins that produce non-tree output.
+    // @ts-ignore - assigning compiler on the processor
+    processor.compiler = extractHeader(
+      depth !== undefined ? { depth } : undefined,
+    );
+    return processor.processSync(markdown);
+  }
+
+  it("attaches headings to file.data using the default depth (3)", () => {
+    const file = compile("# A\n\n## B\n\n### C\n\n#### D\n");
+    expect(file.data.headings).toEqual([
+      { depth: 1, value: "A" },
+      { depth: 2, value: "B" },
+      { depth: 3, value: "C" },
+    ]);
+  });
+
+  it("respects an explicit depth option", () => {
+    const file = compile("# A\n\n## B\n\n### C\n", 2);
+    expect(file.data.headings).toEqual([
+      { depth: 1, value: "A" },
+      { depth: 2, value: "B" },
+    ]);
+  });
+
+  it("produces an empty string as the compiled output", () => {
+    const file = compile("# A\n");
+    expect(String(file)).toBe("");
+  });
+
+  it("sets headings to an empty array for documents without headings", () => {
+    const file = compile("Just text, no headings.\n");
+    expect(file.data.headings).toEqual([]);
+  });
+});

--- a/cli/src/feed.test.ts
+++ b/cli/src/feed.test.ts
@@ -136,9 +136,7 @@ describe("generateFeed", () => {
   it("emits locale-prefixed URLs that match each post's language", async () => {
     await generateFeed(dumpPath, dst);
     const json = JSON.parse(readFileSync(path.join(dst, "feed.json"), "utf-8"));
-    const urls: string[] = json.items.map(
-      (item: { url: string }) => item.url,
-    );
+    const urls: string[] = json.items.map((item: { url: string }) => item.url);
 
     expect(urls).toContain(
       `https://www.illumination-k.dev/ja/techblog/post/${UUID_FIRST}`,

--- a/cli/src/lint.test.ts
+++ b/cli/src/lint.test.ts
@@ -1,0 +1,139 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { lintPosts } from "./lint";
+
+// Long enough title/description to satisfy the SEO linter for lang=ja.
+function validFrontMatter(uuid: string, body = "本文サンプルです。\n"): string {
+  return `---
+uuid: ${uuid}
+title: テスト用のタイトルです。十分な長さがあります。
+description: テスト用のディスクリプションです。SEOの観点から十分な長さになるように書いています。これで五十文字を超えるはずです。
+lang: ja
+category: test
+tags:
+  - tag1
+created_at: "2024-01-01T00:00:00+00:00"
+updated_at: "2024-01-02T00:00:00+00:00"
+---
+
+${body}`;
+}
+
+describe("lintPosts", () => {
+  let workDir: string;
+
+  beforeEach(async () => {
+    workDir = await mkdtemp(path.join(tmpdir(), "cli-lint-test-"));
+  });
+
+  afterEach(async () => {
+    await rm(workDir, { recursive: true, force: true });
+  });
+
+  it("returns an empty array when no markdown files exist", async () => {
+    const errors = await lintPosts(workDir);
+    expect(errors).toEqual([]);
+  });
+
+  it("returns no errors when every post is valid", async () => {
+    await writeFile(
+      path.join(workDir, "ok-1.md"),
+      validFrontMatter("11111111-1111-4111-8111-111111111111"),
+    );
+    await writeFile(
+      path.join(workDir, "ok-2.md"),
+      validFrontMatter("22222222-2222-4222-8222-222222222222"),
+    );
+
+    const errors = await lintPosts(workDir);
+    expect(errors).toEqual([]);
+  });
+
+  it("walks markdown files in nested directories", async () => {
+    const sub = path.join(workDir, "ja", "development");
+    await mkdir(sub, { recursive: true });
+    await writeFile(
+      path.join(sub, "nested.md"),
+      validFrontMatter("33333333-3333-4333-8333-333333333333"),
+    );
+
+    const errors = await lintPosts(workDir);
+    expect(errors).toEqual([]);
+  });
+
+  it("reports SEO errors for posts with overly short titles", async () => {
+    const content = `---
+uuid: 44444444-4444-4444-8444-444444444444
+title: 短い
+description: テスト用のディスクリプションです。SEOの観点から十分な長さになるように書いています。これで五十文字を超えるはずです。
+lang: ja
+category: test
+tags:
+  - tag1
+created_at: "2024-01-01T00:00:00+00:00"
+updated_at: "2024-01-02T00:00:00+00:00"
+---
+
+本文。
+`;
+    await writeFile(path.join(workDir, "bad.md"), content);
+
+    const errors = await lintPosts(workDir);
+    expect(errors.length).toBeGreaterThan(0);
+    const titleError = errors.find((e) =>
+      e.message.includes("title is too short"),
+    );
+    expect(titleError).toBeDefined();
+    expect(titleError?.ruleId).toBe("seo-meta-length");
+    expect(titleError?.file).toContain("bad.md");
+  });
+
+  it("captures lint failures as a LintError instead of throwing", async () => {
+    // Front-matter is unparseable as YAML → fm() will throw → Promise.allSettled
+    // catches it and lintPosts converts it into a "Failed to lint" error.
+    await writeFile(
+      path.join(workDir, "broken.md"),
+      "---\n: invalid : yaml :\n  unmatched indent\n---\nbody\n",
+    );
+
+    const errors = await lintPosts(workDir);
+    const failure = errors.find((e) => e.message.startsWith("Failed to lint"));
+    expect(failure).toBeDefined();
+    expect(failure?.file).toContain("broken.md");
+  });
+
+  it("aggregates errors across multiple files", async () => {
+    // One valid post, one with an SEO error.
+    await writeFile(
+      path.join(workDir, "good.md"),
+      validFrontMatter("55555555-5555-4555-8555-555555555555"),
+    );
+    await writeFile(
+      path.join(workDir, "short-title.md"),
+      `---
+uuid: 66666666-6666-4666-8666-666666666666
+title: 短い
+description: テスト用のディスクリプションです。SEOの観点から十分な長さになるように書いています。これで五十文字を超えるはずです。
+lang: ja
+category: test
+tags:
+  - tag1
+created_at: "2024-01-01T00:00:00+00:00"
+updated_at: "2024-01-02T00:00:00+00:00"
+---
+
+本文。
+`,
+    );
+
+    const errors = await lintPosts(workDir);
+    // All reported errors should originate from the bad file.
+    expect(errors.length).toBeGreaterThan(0);
+    for (const err of errors) {
+      expect(err.file).toContain("short-title.md");
+    }
+  });
+});

--- a/cli/src/migration.test.ts
+++ b/cli/src/migration.test.ts
@@ -1,0 +1,123 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { generateRedirect } from "./migration";
+
+const VALID_FRONT_MATTER = (uuid: string, title = "Title") =>
+  `---
+uuid: ${uuid}
+title: ${title}
+description: A description
+lang: ja
+category: test
+tags:
+  - tag1
+created_at: "2024-01-01T00:00:00+00:00"
+updated_at: "2024-01-02T00:00:00+00:00"
+---
+
+Body content here.
+`;
+
+describe("generateRedirect", () => {
+  let workDir: string;
+
+  beforeEach(async () => {
+    workDir = await mkdtemp(path.join(tmpdir(), "cli-migration-test-"));
+  });
+
+  afterEach(async () => {
+    await rm(workDir, { recursive: true, force: true });
+  });
+
+  it("returns an empty array when no markdown files exist", async () => {
+    const redirects = await generateRedirect(workDir);
+    expect(redirects).toEqual([]);
+  });
+
+  it("creates a redirect for each markdown file using uuid as the destination", async () => {
+    await writeFile(
+      path.join(workDir, "first-post.md"),
+      VALID_FRONT_MATTER("11111111-1111-4111-8111-111111111111", "First"),
+    );
+    await writeFile(
+      path.join(workDir, "second-post.md"),
+      VALID_FRONT_MATTER("22222222-2222-4222-8222-222222222222", "Second"),
+    );
+
+    const redirects = await generateRedirect(workDir);
+
+    expect(redirects).toHaveLength(2);
+    const sorted = [...redirects].sort((a, b) =>
+      a.source.localeCompare(b.source),
+    );
+    expect(sorted).toEqual([
+      {
+        source: "/techblog/posts/first-post",
+        destination: "/techblog/post/11111111-1111-4111-8111-111111111111",
+        permanent: true,
+      },
+      {
+        source: "/techblog/posts/second-post",
+        destination: "/techblog/post/22222222-2222-4222-8222-222222222222",
+        permanent: true,
+      },
+    ]);
+  });
+
+  it("walks markdown files in nested directories", async () => {
+    const nested = path.join(workDir, "ja", "development");
+    await mkdir(nested, { recursive: true });
+    await writeFile(
+      path.join(nested, "nested-post.md"),
+      VALID_FRONT_MATTER("33333333-3333-4333-8333-333333333333"),
+    );
+
+    const redirects = await generateRedirect(workDir);
+
+    expect(redirects).toHaveLength(1);
+    expect(redirects[0]).toEqual({
+      source: "/techblog/posts/nested-post",
+      destination: "/techblog/post/33333333-3333-4333-8333-333333333333",
+      permanent: true,
+    });
+  });
+
+  it("uses only the basename (without .md) as the slug", async () => {
+    const sub = path.join(workDir, "category");
+    await mkdir(sub, { recursive: true });
+    await writeFile(
+      path.join(sub, "my-slug.md"),
+      VALID_FRONT_MATTER("44444444-4444-4444-8444-444444444444"),
+    );
+
+    const [redirect] = await generateRedirect(workDir);
+    expect(redirect.source).toBe("/techblog/posts/my-slug");
+  });
+
+  it("marks every redirect as permanent", async () => {
+    await writeFile(
+      path.join(workDir, "perm.md"),
+      VALID_FRONT_MATTER("55555555-5555-4555-8555-555555555555"),
+    );
+
+    const redirects = await generateRedirect(workDir);
+    expect(redirects.every((r) => r.permanent === true)).toBe(true);
+  });
+
+  it("propagates an error when a post has invalid front-matter", async () => {
+    await writeFile(
+      path.join(workDir, "bad.md"),
+      `---
+uuid: not-a-uuid
+title: Bad
+---
+body
+`,
+    );
+
+    await expect(generateRedirect(workDir)).rejects.toThrow();
+  });
+});

--- a/cli/src/template.test.ts
+++ b/cli/src/template.test.ts
@@ -1,0 +1,116 @@
+import type { PostMeta } from "common";
+import YAML from "yaml";
+import { describe, expect, it } from "vitest";
+
+import { template, templateFromPostMeta } from "./template";
+
+const UUID_V4_REGEX =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+function parseFrontMatter(input: string): Record<string, unknown> {
+  const match = input.match(/^---\n([\s\S]*?)\n---/);
+  if (!match) {
+    throw new Error(`No front-matter delimiter found in: ${input}`);
+  }
+  return YAML.parse(match[1]) as Record<string, unknown>;
+}
+
+describe("template", () => {
+  it("wraps the YAML in front-matter delimiters", () => {
+    const result = template();
+    expect(result.startsWith("---\n")).toBe(true);
+    expect(result).toMatch(/\n---\n$/);
+  });
+
+  it("produces YAML with all required PostMeta fields", () => {
+    const meta = parseFrontMatter(template());
+    expect(meta).toMatchObject({
+      title: "",
+      description: "",
+      category: "",
+      lang: "ja",
+      tags: [],
+    });
+    expect(meta).toHaveProperty("uuid");
+    expect(meta).toHaveProperty("created_at");
+    expect(meta).toHaveProperty("updated_at");
+  });
+
+  it("generates a valid v4 uuid", () => {
+    const meta = parseFrontMatter(template());
+    expect(meta.uuid).toMatch(UUID_V4_REGEX);
+  });
+
+  it("generates a fresh uuid on every call", () => {
+    const a = parseFrontMatter(template());
+    const b = parseFrontMatter(template());
+    expect(a.uuid).not.toBe(b.uuid);
+  });
+
+  it("uses today's date for created_at and updated_at", () => {
+    const meta = parseFrontMatter(template());
+    const today = new Date();
+    const expected = `${today.getFullYear()}-${String(today.getMonth() + 1).padStart(2, "0")}-${String(today.getDate()).padStart(2, "0")}`;
+    expect(meta.created_at).toBe(expected);
+    expect(meta.updated_at).toBe(expected);
+  });
+
+  it("uses the provided tags array", () => {
+    const meta = parseFrontMatter(template(["typescript", "react"]));
+    expect(meta.tags).toEqual(["typescript", "react"]);
+  });
+
+  it("falls back to an empty tags array when none are provided", () => {
+    const meta = parseFrontMatter(template());
+    expect(meta.tags).toEqual([]);
+  });
+
+  it("falls back to an empty tags array when an empty array is passed (truthy fallback semantics)", () => {
+    // Note: template(undefined) and template([]) currently differ — empty
+    // array is truthy so it overrides the default. This pins that behavior.
+    const meta = parseFrontMatter(template([]));
+    expect(meta.tags).toEqual([]);
+  });
+});
+
+describe("templateFromPostMeta", () => {
+  function makePostMeta(): PostMeta {
+    return {
+      uuid: "abcdef01-2345-4678-89ab-cdef01234567",
+      title: "Existing Title",
+      description: "Existing Description",
+      category: "techblog",
+      lang: "en",
+      tags: ["existing", "tag"],
+      created_at: "2024-05-01",
+      updated_at: "2024-05-15",
+    };
+  }
+
+  it("starts with the front-matter delimiter", () => {
+    const result = templateFromPostMeta(makePostMeta());
+    expect(result.startsWith("---\n")).toBe(true);
+  });
+
+  it("emits every field from the input PostMeta", () => {
+    const input = makePostMeta();
+    const result = templateFromPostMeta(input);
+    // Strip the leading ---\n so the rest is plain YAML
+    const yamlBody = result.replace(/^---\n/, "").trimEnd();
+    const parsed = YAML.parse(yamlBody) as PostMeta;
+
+    expect(parsed).toEqual(input);
+  });
+
+  it("preserves a custom uuid (does not overwrite it)", () => {
+    const input = makePostMeta();
+    const result = templateFromPostMeta(input);
+    expect(result).toContain("uuid: abcdef01-2345-4678-89ab-cdef01234567");
+  });
+
+  it("preserves the existing tags list", () => {
+    const result = templateFromPostMeta(makePostMeta());
+    expect(result).toContain("- existing");
+    expect(result).toContain("- tag");
+  });
+});

--- a/cli/src/template.test.ts
+++ b/cli/src/template.test.ts
@@ -1,6 +1,6 @@
 import type { PostMeta } from "common";
-import YAML from "yaml";
 import { describe, expect, it } from "vitest";
+import YAML from "yaml";
 
 import { template, templateFromPostMeta } from "./template";
 

--- a/packages/common/profile.test.ts
+++ b/packages/common/profile.test.ts
@@ -1,0 +1,229 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  profileDumpSchema,
+  profileEducationSchema,
+  profileEmploymentSchema,
+  profileWorkAuthorSchema,
+  profileWorkSchema,
+} from "./profile";
+
+describe("profileEmploymentSchema", () => {
+  it("parses a fully populated employment record", () => {
+    const result = profileEmploymentSchema.parse({
+      organizationName: "Acme Corp",
+      departmentName: "Research",
+      role: "Engineer",
+      startDate: "2020-01",
+      endDate: "2023-12",
+    });
+
+    expect(result.organizationName).toBe("Acme Corp");
+    expect(result.role).toBe("Engineer");
+  });
+
+  it("requires organizationName", () => {
+    expect(() => profileEmploymentSchema.parse({})).toThrow();
+  });
+
+  it("treats departmentName, role, startDate and endDate as optional", () => {
+    const result = profileEmploymentSchema.parse({
+      organizationName: "Solo LLC",
+    });
+    expect(result.organizationName).toBe("Solo LLC");
+    expect(result.departmentName).toBeUndefined();
+    expect(result.role).toBeUndefined();
+    expect(result.startDate).toBeUndefined();
+    expect(result.endDate).toBeUndefined();
+  });
+
+  it("rejects non-string organizationName", () => {
+    expect(() =>
+      profileEmploymentSchema.parse({ organizationName: 42 }),
+    ).toThrow();
+  });
+});
+
+describe("profileEducationSchema", () => {
+  it("parses a fully populated education record", () => {
+    const result = profileEducationSchema.parse({
+      organizationName: "University X",
+      departmentName: "CS",
+      role: "PhD",
+      startDate: "2015",
+      endDate: "2019",
+    });
+    expect(result.organizationName).toBe("University X");
+    expect(result.role).toBe("PhD");
+  });
+
+  it("requires organizationName", () => {
+    expect(() => profileEducationSchema.parse({ role: "Student" })).toThrow();
+  });
+
+  it("accepts the minimum shape (just organizationName)", () => {
+    const result = profileEducationSchema.parse({
+      organizationName: "Some School",
+    });
+    expect(result.organizationName).toBe("Some School");
+  });
+});
+
+describe("profileWorkAuthorSchema", () => {
+  it("parses a name-only author", () => {
+    const result = profileWorkAuthorSchema.parse({ name: "Jane Doe" });
+    expect(result).toEqual({ name: "Jane Doe" });
+  });
+
+  it("parses a name with an ORCID", () => {
+    const result = profileWorkAuthorSchema.parse({
+      name: "Jane Doe",
+      orcid: "0000-0000-0000-0001",
+    });
+    expect(result.orcid).toBe("0000-0000-0000-0001");
+  });
+
+  it("requires name", () => {
+    expect(() => profileWorkAuthorSchema.parse({})).toThrow();
+  });
+});
+
+describe("profileWorkSchema", () => {
+  it("requires only the title field", () => {
+    const result = profileWorkSchema.parse({ title: "A Paper" });
+    expect(result.title).toBe("A Paper");
+    expect(result.authors).toBeUndefined();
+  });
+
+  it("parses a fully populated work record", () => {
+    const result = profileWorkSchema.parse({
+      title: "Reproducible Research",
+      journalTitle: "Nature",
+      publicationYear: 2023,
+      doi: "10.1000/example",
+      url: "https://example.com/paper",
+      type: "journal-article",
+      citationCount: 42,
+      authors: [
+        { name: "Alice", orcid: "0000-0000-0000-0001" },
+        { name: "Bob" },
+      ],
+    });
+
+    expect(result.publicationYear).toBe(2023);
+    expect(result.citationCount).toBe(42);
+    expect(result.authors).toHaveLength(2);
+    expect(result.authors?.[0].orcid).toBe("0000-0000-0000-0001");
+  });
+
+  it("rejects non-numeric publicationYear", () => {
+    expect(() =>
+      profileWorkSchema.parse({ title: "X", publicationYear: "2023" }),
+    ).toThrow();
+  });
+
+  it("rejects non-numeric citationCount", () => {
+    expect(() =>
+      profileWorkSchema.parse({ title: "X", citationCount: "42" }),
+    ).toThrow();
+  });
+
+  it("rejects authors entries missing a name", () => {
+    expect(() =>
+      profileWorkSchema.parse({
+        title: "X",
+        authors: [{ orcid: "0000-0000-0000-0001" }],
+      }),
+    ).toThrow();
+  });
+
+  it("requires title", () => {
+    expect(() => profileWorkSchema.parse({})).toThrow();
+  });
+});
+
+describe("profileDumpSchema", () => {
+  function validDump() {
+    return {
+      orcidId: "0000-0000-0000-0001",
+      fetchedAt: "2024-05-01T12:00:00Z",
+      ownerNames: ["Jane Doe"],
+      employments: [{ organizationName: "Acme" }],
+      educations: [{ organizationName: "University X" }],
+      works: [{ title: "Paper One" }],
+    };
+  }
+
+  it("parses a complete dump", () => {
+    const result = profileDumpSchema.parse(validDump());
+    expect(result.orcidId).toBe("0000-0000-0000-0001");
+    expect(result.ownerNames).toEqual(["Jane Doe"]);
+    expect(result.works).toHaveLength(1);
+  });
+
+  it("defaults ownerNames to an empty array when omitted", () => {
+    const { ownerNames: _omitted, ...dump } = validDump();
+    const result = profileDumpSchema.parse(dump);
+    expect(result.ownerNames).toEqual([]);
+  });
+
+  it("requires orcidId", () => {
+    const { orcidId: _omitted, ...dump } = validDump();
+    expect(() => profileDumpSchema.parse(dump)).toThrow();
+  });
+
+  it("requires fetchedAt", () => {
+    const { fetchedAt: _omitted, ...dump } = validDump();
+    expect(() => profileDumpSchema.parse(dump)).toThrow();
+  });
+
+  it("requires employments to be an array", () => {
+    expect(() =>
+      profileDumpSchema.parse({ ...validDump(), employments: "nope" }),
+    ).toThrow();
+  });
+
+  it("requires educations to be an array", () => {
+    expect(() =>
+      profileDumpSchema.parse({ ...validDump(), educations: null }),
+    ).toThrow();
+  });
+
+  it("requires works to be an array", () => {
+    expect(() =>
+      profileDumpSchema.parse({ ...validDump(), works: undefined }),
+    ).toThrow();
+  });
+
+  it("rejects an employments entry with the wrong shape", () => {
+    expect(() =>
+      profileDumpSchema.parse({
+        ...validDump(),
+        employments: [{ role: "missing org name" }],
+      }),
+    ).toThrow();
+  });
+
+  it("rejects a works entry without a title", () => {
+    expect(() =>
+      profileDumpSchema.parse({
+        ...validDump(),
+        works: [{ journalTitle: "no title here" }],
+      }),
+    ).toThrow();
+  });
+
+  it("accepts empty arrays for employments, educations and works", () => {
+    const result = profileDumpSchema.parse({
+      orcidId: "0000-0000-0000-0001",
+      fetchedAt: "2024-05-01T12:00:00Z",
+      employments: [],
+      educations: [],
+      works: [],
+    });
+    expect(result.employments).toEqual([]);
+    expect(result.educations).toEqual([]);
+    expect(result.works).toEqual([]);
+    expect(result.ownerNames).toEqual([]);
+  });
+});

--- a/packages/common/profileIo.test.ts
+++ b/packages/common/profileIo.test.ts
@@ -1,0 +1,108 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { ProfileDump } from "./profile";
+import { readProfileDump } from "./profileIo";
+
+function makeValidDump(): ProfileDump {
+  return {
+    orcidId: "0000-0000-0000-0001",
+    fetchedAt: "2024-05-01T12:00:00Z",
+    ownerNames: ["Jane Doe"],
+    employments: [{ organizationName: "Acme Corp", role: "Researcher" }],
+    educations: [{ organizationName: "University X", departmentName: "CS" }],
+    works: [
+      {
+        title: "A Paper",
+        publicationYear: 2023,
+        authors: [{ name: "Jane Doe", orcid: "0000-0000-0000-0001" }],
+      },
+    ],
+  };
+}
+
+describe("readProfileDump", () => {
+  let workDir: string;
+
+  beforeEach(() => {
+    workDir = mkdtempSync(path.join(tmpdir(), "common-profile-io-test-"));
+  });
+
+  afterEach(() => {
+    rmSync(workDir, { recursive: true, force: true });
+  });
+
+  it("parses a valid profile dump", async () => {
+    const dumpPath = path.join(workDir, "profile.json");
+    writeFileSync(dumpPath, JSON.stringify(makeValidDump()));
+
+    const result = await readProfileDump(dumpPath);
+
+    expect(result.orcidId).toBe("0000-0000-0000-0001");
+    expect(result.ownerNames).toEqual(["Jane Doe"]);
+    expect(result.employments).toHaveLength(1);
+    expect(result.employments[0].organizationName).toBe("Acme Corp");
+    expect(result.works[0].title).toBe("A Paper");
+    expect(result.works[0].authors?.[0].orcid).toBe("0000-0000-0000-0001");
+  });
+
+  it("defaults ownerNames to [] when the field is missing from the file", async () => {
+    const dumpPath = path.join(workDir, "profile.json");
+    const { ownerNames: _omitted, ...dump } = makeValidDump();
+    writeFileSync(dumpPath, JSON.stringify(dump));
+
+    const result = await readProfileDump(dumpPath);
+    expect(result.ownerNames).toEqual([]);
+  });
+
+  it("throws 'Invalid profile dump file' when schema validation fails", async () => {
+    const dumpPath = path.join(workDir, "profile.json");
+    writeFileSync(
+      dumpPath,
+      JSON.stringify({
+        orcidId: "0000-0000-0000-0001",
+        // Missing fetchedAt, employments, educations, works.
+      }),
+    );
+
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await expect(readProfileDump(dumpPath)).rejects.toBe(
+      "Invalid profile dump file",
+    );
+    expect(errorSpy).toHaveBeenCalled();
+
+    errorSpy.mockRestore();
+  });
+
+  it("throws when the JSON is malformed", async () => {
+    const dumpPath = path.join(workDir, "profile.json");
+    writeFileSync(dumpPath, "{ not valid json");
+
+    await expect(readProfileDump(dumpPath)).rejects.toBeInstanceOf(SyntaxError);
+  });
+
+  it("rejects when the file does not exist", async () => {
+    await expect(
+      readProfileDump(path.join(workDir, "missing.json")),
+    ).rejects.toBeDefined();
+  });
+
+  it("throws when works contain an entry missing the title field", async () => {
+    const dumpPath = path.join(workDir, "profile.json");
+    const dump = makeValidDump();
+    // @ts-expect-error - intentionally invalid for test
+    dump.works = [{ journalTitle: "no title" }];
+    writeFileSync(dumpPath, JSON.stringify(dump));
+
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await expect(readProfileDump(dumpPath)).rejects.toBe(
+      "Invalid profile dump file",
+    );
+
+    errorSpy.mockRestore();
+  });
+});

--- a/web/src/data/metrics-history.ndjson
+++ b/web/src/data/metrics-history.ndjson
@@ -20,3 +20,4 @@
 {"date":"2026-04-13","sha":"aef9c9e","pr":162,"coverage":{"lines":57.14,"statements":56.88,"functions":46.14,"branches":54.3},"mutation":{"score":45.78,"killed":1275,"survived":1515,"timeout":4,"noCoverage":0,"total":2794}}
 {"date":"2026-04-13","sha":"6038c30","pr":163,"coverage":{"lines":59.06,"statements":59.02,"functions":49.28,"branches":54.95},"mutation":{"score":46.08,"killed":1290,"survived":1514,"timeout":4,"noCoverage":0,"total":2808}}
 {"date":"2026-04-14","sha":"43dd16d","pr":164,"coverage":{"lines":69.77,"statements":69.32,"functions":66.03,"branches":61.84},"mutation":{"score":45.34,"killed":1534,"survived":1858,"timeout":7,"noCoverage":0,"total":3399}}
+{"date":"2026-04-14","sha":"171857d","pr":165,"coverage":{"lines":72.02,"statements":71.49,"functions":67.46,"branches":62.68},"mutation":{"score":46.72,"killed":1581,"survived":1811,"timeout":7,"noCoverage":0,"total":3399}}


### PR DESCRIPTION
Cover modules previously lacking any test coverage:

- cli/src/extractHeader.ts: heading extraction + depth filtering and
  the unified compiler that attaches headings to file.data
- cli/src/migration.ts: redirect generation from markdown files
- cli/src/template.ts: template() and templateFromPostMeta() YAML output
- cli/src/lint.ts: lintPosts() orchestration including SEO error
  reporting and Promise.allSettled failure aggregation
- packages/common/profile.ts: validation for all five profile Zod
  schemas (employment, education, work author, work, dump)
- packages/common/profileIo.ts: readProfileDump() success and error
  paths (schema failure, malformed JSON, missing file)

cli: 14 test files / 184 passed (was 9 / ~140)
common: 5 test files / 60 passed (was 3 / 28)