### PR TITLE
claude/tag-network-visualization-NDYGY

### DIFF
--- a/web/src/app/[locale]/(articles)/_factory/pagerFactory.test.tsx
+++ b/web/src/app/[locale]/(articles)/_factory/pagerFactory.test.tsx
@@ -47,6 +47,7 @@ function makeService(posts: DumpPost[]): BlogService {
     categories: async () => [],
     tags: async () => [],
     filterPosts,
+    tagNetwork: async () => ({ nodes: [], edges: [] }),
   });
 }
 

--- a/web/src/app/[locale]/(articles)/_factory/postPageFactory.test.tsx
+++ b/web/src/app/[locale]/(articles)/_factory/postPageFactory.test.tsx
@@ -52,6 +52,7 @@ function makeService(posts: DumpPost[]): BlogService {
     categories: async () => [],
     tags: async () => [],
     filterPosts: async () => posts,
+    tagNetwork: async () => ({ nodes: [], edges: [] }),
   });
 }
 

--- a/web/src/app/[locale]/(articles)/_factory/tagFactory.test.tsx
+++ b/web/src/app/[locale]/(articles)/_factory/tagFactory.test.tsx
@@ -60,6 +60,7 @@ function makeService(opts: {
         return true;
       });
     },
+    tagNetwork: async () => ({ nodes: [], edges: [] }),
   });
 }
 
@@ -183,10 +184,16 @@ describe("TagTopPageFactory", () => {
       params: Promise.resolve({ locale: "ja" }),
     });
 
-    // Returned a React element; tag list must include 3 children
+    // Returned a React element with network link + tag list
     expect(result).toBeTruthy();
     const element = result as ReactElement<{ children: ReactNode }>;
     const children = element.props.children;
-    expect(Array.isArray(children) ? children.length : 0).toBe(3);
+    // children[0] = network link div, children[1] = tag list div
+    expect(Array.isArray(children) ? children.length : 0).toBe(2);
+    const tagListDiv = (children as ReactElement[])[1] as ReactElement<{
+      children: ReactNode;
+    }>;
+    const tags = tagListDiv.props.children;
+    expect(Array.isArray(tags) ? tags.length : 0).toBe(3);
   });
 });

--- a/web/src/app/[locale]/(articles)/_factory/tagFactory.tsx
+++ b/web/src/app/[locale]/(articles)/_factory/tagFactory.tsx
@@ -1,6 +1,7 @@
+import Link from "next/link";
+
 import { css } from "@/styled-system/css";
 
-import Link from "next/link";
 import type { Metadata, ResolvingMetadata, Route } from "next";
 import { z } from "zod";
 
@@ -183,9 +184,7 @@ export class TagTopPageFactory {
             })}
           >
             <Link
-              href={
-                `/${locale}/${this.prefix}/tag/network` as Route
-              }
+              href={`/${locale}/${this.prefix}/tag/network` as Route}
               className={css({
                 display: "inline-flex",
                 alignItems: "center",

--- a/web/src/app/[locale]/(articles)/_factory/tagFactory.tsx
+++ b/web/src/app/[locale]/(articles)/_factory/tagFactory.tsx
@@ -1,5 +1,6 @@
 import { css } from "@/styled-system/css";
 
+import Link from "next/link";
 import type { Metadata, ResolvingMetadata, Route } from "next";
 import { z } from "zod";
 
@@ -170,19 +171,61 @@ export class TagTopPageFactory {
       const { locale: localeParam } = await params;
       const locale: Locale = isLocale(localeParam) ? localeParam : "ja";
       const tags = await this.blogService.repo.tags();
+      const dict = await getDictionary(locale);
 
       return (
-        <div
-          className={css({ p: 5, display: "flex", flexWrap: "wrap", gap: 3 })}
-        >
-          {tags.map((tag) => (
-            <Tag
-              key={tag}
-              prefix={`${locale}/${this.prefix}`}
-              tag={tag}
-              className={css({})}
-            />
-          ))}
+        <div className={css({ p: 5 })}>
+          <div
+            className={css({
+              display: "flex",
+              justifyContent: "flex-end",
+              mb: 4,
+            })}
+          >
+            <Link
+              href={
+                `/${locale}/${this.prefix}/tag/network` as Route
+              }
+              className={css({
+                display: "inline-flex",
+                alignItems: "center",
+                gap: 1.5,
+                px: 4,
+                py: 2,
+                borderRadius: "lg",
+                fontSize: "sm",
+                fontWeight: "medium",
+                bg: "bg.surface",
+                color: "accent.primary",
+                border: "1px solid",
+                borderColor: "border.default",
+                transition: "all",
+                transitionDuration: "fast",
+                _hover: {
+                  bg: "accent.muted",
+                  borderColor: "accent.primary",
+                },
+              })}
+            >
+              {dict.meta.tagNetwork(this.prefix)}
+            </Link>
+          </div>
+          <div
+            className={css({
+              display: "flex",
+              flexWrap: "wrap",
+              gap: 3,
+            })}
+          >
+            {tags.map((tag) => (
+              <Tag
+                key={tag}
+                prefix={`${locale}/${this.prefix}`}
+                tag={tag}
+                className={css({})}
+              />
+            ))}
+          </div>
         </div>
       );
     };

--- a/web/src/app/[locale]/(articles)/techblog/tag/network/page.tsx
+++ b/web/src/app/[locale]/(articles)/techblog/tag/network/page.tsx
@@ -1,15 +1,11 @@
+import { css } from "@/styled-system/css";
+
 import type { Metadata } from "next";
 
-import { css } from "@/styled-system/css";
 
 import TagNetwork from "@/features/articles/components/TagNetwork";
 import { blogService } from "@/features/techblog/constant";
-import {
-  type Locale,
-  getDictionary,
-  isLocale,
-  localeToLang,
-} from "@/lib/i18n";
+import { type Locale, getDictionary, isLocale, localeToLang } from "@/lib/i18n";
 
 export async function generateMetadata({
   params,

--- a/web/src/app/[locale]/(articles)/techblog/tag/network/page.tsx
+++ b/web/src/app/[locale]/(articles)/techblog/tag/network/page.tsx
@@ -1,0 +1,103 @@
+import type { Metadata } from "next";
+
+import { css } from "@/styled-system/css";
+
+import TagNetwork from "@/features/articles/components/TagNetwork";
+import { blogService } from "@/features/techblog/constant";
+import {
+  type Locale,
+  getDictionary,
+  isLocale,
+  localeToLang,
+} from "@/lib/i18n";
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ locale: string }>;
+}): Promise<Metadata> {
+  const { locale: localeParam } = await params;
+  const locale: Locale = isLocale(localeParam) ? localeParam : "ja";
+  const dict = await getDictionary(locale);
+
+  const title = dict.meta.tagNetwork("techblog");
+  const description = dict.meta.tagNetworkDescription("techblog");
+
+  return {
+    title,
+    description,
+    openGraph: {
+      title,
+      description,
+      url: `https://www.illumination-k.dev/${locale}/techblog/tag/network`,
+    },
+  };
+}
+
+export default async function TagNetworkPage({
+  params,
+}: {
+  params: Promise<{ locale: string }>;
+}) {
+  const { locale: localeParam } = await params;
+  const locale: Locale = isLocale(localeParam) ? localeParam : "ja";
+  const lang = localeToLang(locale);
+  const dict = await getDictionary(locale);
+
+  const networkData = await blogService.repo.tagNetwork(lang);
+
+  return (
+    <div
+      className={css({
+        bg: "bg.page",
+        display: "grid",
+        gridTemplateColumns: "repeat(12, minmax(0, 1fr))",
+      })}
+    >
+      <div
+        className={css({
+          gridColumnStart: "1",
+          gridColumnEnd: "-1",
+          lg: { gridColumnStart: "2", gridColumnEnd: "12" },
+          p: 4,
+        })}
+      >
+        <h1
+          className={css({
+            fontSize: "2xl",
+            fontWeight: "bold",
+            color: "text.primary",
+            mb: 2,
+          })}
+        >
+          {dict.meta.tagNetwork("techblog")}
+        </h1>
+        <p
+          className={css({
+            fontSize: "sm",
+            color: "text.secondary",
+            mb: 4,
+          })}
+        >
+          {dict.meta.tagNetworkDescription("techblog")}
+        </p>
+        <div
+          className={css({
+            bg: "bg.surface",
+            borderRadius: "xl",
+            border: "1px solid",
+            borderColor: "border.default",
+            overflow: "hidden",
+            position: "relative",
+          })}
+        >
+          <TagNetwork
+            nodes={networkData.nodes}
+            edges={networkData.edges}
+            prefix={`${locale}/techblog`}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/src/app/[locale]/(articles)/techblog/tag/network/page.tsx
+++ b/web/src/app/[locale]/(articles)/techblog/tag/network/page.tsx
@@ -2,7 +2,6 @@ import { css } from "@/styled-system/css";
 
 import type { Metadata } from "next";
 
-
 import TagNetwork from "@/features/articles/components/TagNetwork";
 import { blogService } from "@/features/techblog/constant";
 import { type Locale, getDictionary, isLocale, localeToLang } from "@/lib/i18n";

--- a/web/src/app/sitemap.test.ts
+++ b/web/src/app/sitemap.test.ts
@@ -113,6 +113,7 @@ const shared = vi.hoisted(() => {
         }),
       retrieve: async () => undefined,
       categories: async () => dump.categories,
+      tagNetwork: async () => ({ nodes: [], edges: [] }),
     },
   });
 

--- a/web/src/data/metrics-history.ndjson
+++ b/web/src/data/metrics-history.ndjson
@@ -21,3 +21,4 @@
 {"date":"2026-04-13","sha":"6038c30","pr":163,"coverage":{"lines":59.06,"statements":59.02,"functions":49.28,"branches":54.95},"mutation":{"score":46.08,"killed":1290,"survived":1514,"timeout":4,"noCoverage":0,"total":2808}}
 {"date":"2026-04-14","sha":"43dd16d","pr":164,"coverage":{"lines":69.77,"statements":69.32,"functions":66.03,"branches":61.84},"mutation":{"score":45.34,"killed":1534,"survived":1858,"timeout":7,"noCoverage":0,"total":3399}}
 {"date":"2026-04-14","sha":"171857d","pr":165,"coverage":{"lines":72.02,"statements":71.49,"functions":67.46,"branches":62.68},"mutation":{"score":46.72,"killed":1581,"survived":1811,"timeout":7,"noCoverage":0,"total":3399}}
+{"date":"2026-04-16","sha":"ce4b2bb","pr":166,"coverage":{"lines":61.9,"statements":61.46,"functions":62.06,"branches":54.57},"mutation":{"score":45.92,"killed":1581,"survived":1870,"timeout":7,"noCoverage":0,"total":3458}}

--- a/web/src/features/articles/components/TagNetwork.tsx
+++ b/web/src/features/articles/components/TagNetwork.tsx
@@ -1,9 +1,9 @@
 "use client";
 
+import { useRouter } from "next/navigation";
 import { useCallback, useEffect, useRef, useState } from "react";
 
 import type { Route } from "next";
-import { useRouter } from "next/navigation";
 
 interface TagNode {
   tag: string;
@@ -282,11 +282,7 @@ export default function TagNetwork({ nodes, edges, prefix }: TagNetworkProps) {
       // Draw count inside node
       if (n.radius >= 14) {
         ctx.font = `bold ${Math.max(9, fontSize - 2)}px system-ui, -apple-system, sans-serif`;
-        ctx.fillStyle = isHovered
-          ? "#ffffff"
-          : dark
-            ? "#7dd3fc"
-            : "#1e40af";
+        ctx.fillStyle = isHovered ? "#ffffff" : dark ? "#7dd3fc" : "#1e40af";
         ctx.fillText(String(n.count), n.x, n.y);
       }
     }
@@ -355,19 +351,16 @@ export default function TagNetwork({ nodes, edges, prefix }: TagNetworkProps) {
     return null;
   }, []);
 
-  const getCanvasPos = useCallback(
-    (e: React.MouseEvent | React.TouchEvent) => {
-      const canvas = canvasRef.current;
-      if (!canvas) return { x: 0, y: 0 };
-      const rect = canvas.getBoundingClientRect();
-      const clientX =
-        "touches" in e ? e.touches[0].clientX : (e as React.MouseEvent).clientX;
-      const clientY =
-        "touches" in e ? e.touches[0].clientY : (e as React.MouseEvent).clientY;
-      return { x: clientX - rect.left, y: clientY - rect.top };
-    },
-    [],
-  );
+  const getCanvasPos = useCallback((e: React.MouseEvent | React.TouchEvent) => {
+    const canvas = canvasRef.current;
+    if (!canvas) return { x: 0, y: 0 };
+    const rect = canvas.getBoundingClientRect();
+    const clientX =
+      "touches" in e ? e.touches[0].clientX : (e as React.MouseEvent).clientX;
+    const clientY =
+      "touches" in e ? e.touches[0].clientY : (e as React.MouseEvent).clientY;
+    return { x: clientX - rect.left, y: clientY - rect.top };
+  }, []);
 
   const handlePointerDown = useCallback(
     (e: React.MouseEvent) => {

--- a/web/src/features/articles/components/TagNetwork.tsx
+++ b/web/src/features/articles/components/TagNetwork.tsx
@@ -1,0 +1,462 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import type { Route } from "next";
+import { useRouter } from "next/navigation";
+
+interface TagNode {
+  tag: string;
+  count: number;
+  x: number;
+  y: number;
+  vx: number;
+  vy: number;
+  radius: number;
+}
+
+interface TagEdge {
+  source: string;
+  target: string;
+  weight: number;
+}
+
+interface TagNetworkProps {
+  nodes: { tag: string; count: number }[];
+  edges: { source: string; target: string; weight: number }[];
+  prefix: string;
+}
+
+const NODE_MIN_RADIUS = 8;
+const NODE_MAX_RADIUS = 32;
+const REPULSION = 800;
+const ATTRACTION = 0.005;
+const EDGE_REST_LENGTH = 120;
+const DAMPING = 0.85;
+const MIN_VELOCITY = 0.01;
+
+function lerp(a: number, b: number, t: number): number {
+  return a + (b - a) * t;
+}
+
+export default function TagNetwork({ nodes, edges, prefix }: TagNetworkProps) {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const nodesRef = useRef<TagNode[]>([]);
+  const edgesRef = useRef<TagEdge[]>(edges);
+  const animRef = useRef<number>(0);
+  const draggingRef = useRef<TagNode | null>(null);
+  const hoveredRef = useRef<TagNode | null>(null);
+  const offsetRef = useRef({ x: 0, y: 0 });
+  const sizeRef = useRef({ width: 800, height: 600 });
+  const [hovered, setHovered] = useState<string | null>(null);
+  const router = useRouter();
+
+  const isDarkRef = useRef(false);
+
+  useEffect(() => {
+    const check = () => {
+      const el = document.documentElement;
+      isDarkRef.current = el.getAttribute("data-color-mode") === "dark";
+    };
+    check();
+    const observer = new MutationObserver(check);
+    observer.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ["data-color-mode"],
+    });
+    return () => observer.disconnect();
+  }, []);
+
+  // Initialize nodes with positions
+  useEffect(() => {
+    const maxCount = Math.max(...nodes.map((n) => n.count), 1);
+    const { width, height } = sizeRef.current;
+    const cx = width / 2;
+    const cy = height / 2;
+
+    nodesRef.current = nodes.map((n, i) => {
+      const t = n.count / maxCount;
+      const radius = lerp(NODE_MIN_RADIUS, NODE_MAX_RADIUS, t);
+      const angle = (2 * Math.PI * i) / nodes.length;
+      const spread = Math.min(width, height) * 0.35;
+      return {
+        ...n,
+        x: cx + Math.cos(angle) * spread * (0.5 + Math.random() * 0.5),
+        y: cy + Math.sin(angle) * spread * (0.5 + Math.random() * 0.5),
+        vx: 0,
+        vy: 0,
+        radius,
+      };
+    });
+    edgesRef.current = edges;
+  }, [nodes, edges]);
+
+  const simulate = useCallback(() => {
+    const ns = nodesRef.current;
+    const es = edgesRef.current;
+    const { width, height } = sizeRef.current;
+
+    const nodeMap = new Map<string, TagNode>();
+    for (const n of ns) {
+      nodeMap.set(n.tag, n);
+    }
+
+    // Repulsion between all pairs
+    for (let i = 0; i < ns.length; i++) {
+      for (let j = i + 1; j < ns.length; j++) {
+        const a = ns[i];
+        const b = ns[j];
+        let dx = a.x - b.x;
+        let dy = a.y - b.y;
+        const dist = Math.sqrt(dx * dx + dy * dy) || 1;
+        const force = REPULSION / (dist * dist);
+        dx = (dx / dist) * force;
+        dy = (dy / dist) * force;
+        a.vx += dx;
+        a.vy += dy;
+        b.vx -= dx;
+        b.vy -= dy;
+      }
+    }
+
+    // Attraction along edges
+    for (const e of es) {
+      const a = nodeMap.get(e.source);
+      const b = nodeMap.get(e.target);
+      if (!a || !b) continue;
+      const dx = b.x - a.x;
+      const dy = b.y - a.y;
+      const dist = Math.sqrt(dx * dx + dy * dy) || 1;
+      const force = (dist - EDGE_REST_LENGTH) * ATTRACTION * e.weight;
+      const fx = (dx / dist) * force;
+      const fy = (dy / dist) * force;
+      a.vx += fx;
+      a.vy += fy;
+      b.vx -= fx;
+      b.vy -= fy;
+    }
+
+    // Center gravity
+    const cx = width / 2;
+    const cy = height / 2;
+    for (const n of ns) {
+      n.vx += (cx - n.x) * 0.001;
+      n.vy += (cy - n.y) * 0.001;
+    }
+
+    // Update positions
+    let moving = false;
+    for (const n of ns) {
+      if (n === draggingRef.current) {
+        n.vx = 0;
+        n.vy = 0;
+        continue;
+      }
+      n.vx *= DAMPING;
+      n.vy *= DAMPING;
+      n.x += n.vx;
+      n.y += n.vy;
+
+      // Keep in bounds
+      const margin = n.radius + 2;
+      n.x = Math.max(margin, Math.min(width - margin, n.x));
+      n.y = Math.max(margin, Math.min(height - margin, n.y));
+
+      if (Math.abs(n.vx) > MIN_VELOCITY || Math.abs(n.vy) > MIN_VELOCITY) {
+        moving = true;
+      }
+    }
+
+    return moving;
+  }, []);
+
+  const draw = useCallback(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return;
+
+    const dark = isDarkRef.current;
+    const ns = nodesRef.current;
+    const es = edgesRef.current;
+    const nodeMap = new Map<string, TagNode>();
+    for (const n of ns) {
+      nodeMap.set(n.tag, n);
+    }
+
+    const dpr = window.devicePixelRatio || 1;
+    const { width, height } = sizeRef.current;
+    canvas.width = width * dpr;
+    canvas.height = height * dpr;
+    canvas.style.width = `${width}px`;
+    canvas.style.height = `${height}px`;
+    ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+
+    // Clear
+    ctx.clearRect(0, 0, width, height);
+
+    // Draw edges
+    const maxWeight = Math.max(...es.map((e) => e.weight), 1);
+    for (const e of es) {
+      const a = nodeMap.get(e.source);
+      const b = nodeMap.get(e.target);
+      if (!a || !b) continue;
+
+      const isHighlighted =
+        hoveredRef.current &&
+        (e.source === hoveredRef.current.tag ||
+          e.target === hoveredRef.current.tag);
+
+      const alpha = isHighlighted
+        ? 0.8
+        : hoveredRef.current
+          ? 0.08
+          : lerp(0.1, 0.5, e.weight / maxWeight);
+
+      ctx.beginPath();
+      ctx.moveTo(a.x, a.y);
+      ctx.lineTo(b.x, b.y);
+      ctx.strokeStyle = dark
+        ? `rgba(148, 163, 184, ${alpha})`
+        : `rgba(71, 85, 105, ${alpha})`;
+      ctx.lineWidth = isHighlighted
+        ? lerp(1.5, 4, e.weight / maxWeight)
+        : lerp(0.5, 3, e.weight / maxWeight);
+      ctx.stroke();
+    }
+
+    // Draw nodes
+    for (const n of ns) {
+      const isHovered = hoveredRef.current === n;
+      const isConnected =
+        hoveredRef.current &&
+        es.some(
+          (e) =>
+            (e.source === hoveredRef.current!.tag && e.target === n.tag) ||
+            (e.target === hoveredRef.current!.tag && e.source === n.tag),
+        );
+      const dimmed = hoveredRef.current && !isHovered && !isConnected;
+
+      ctx.beginPath();
+      ctx.arc(n.x, n.y, n.radius, 0, Math.PI * 2);
+
+      if (isHovered) {
+        ctx.fillStyle = dark ? "#38bdf8" : "#0ea5e9";
+      } else if (dimmed) {
+        ctx.fillStyle = dark
+          ? "rgba(30, 58, 95, 0.5)"
+          : "rgba(219, 234, 254, 0.5)";
+      } else {
+        ctx.fillStyle = dark ? "#1e3a5f" : "#dbeafe";
+      }
+      ctx.fill();
+
+      ctx.strokeStyle = isHovered
+        ? dark
+          ? "#7dd3fc"
+          : "#0284c7"
+        : dark
+          ? "rgba(56, 189, 248, 0.4)"
+          : "rgba(14, 165, 233, 0.4)";
+      ctx.lineWidth = isHovered ? 2.5 : 1.5;
+      ctx.stroke();
+
+      // Label
+      const fontSize = Math.max(10, Math.min(14, n.radius * 0.8));
+      ctx.font = `${isHovered ? "bold " : ""}${fontSize}px system-ui, -apple-system, sans-serif`;
+      ctx.textAlign = "center";
+      ctx.textBaseline = "middle";
+
+      if (dimmed) {
+        ctx.fillStyle = dark
+          ? "rgba(148, 163, 184, 0.3)"
+          : "rgba(71, 85, 105, 0.3)";
+      } else {
+        ctx.fillStyle = dark ? "#e2e8f0" : "#0f172a";
+      }
+
+      // Draw label below node
+      ctx.fillText(n.tag, n.x, n.y + n.radius + fontSize * 0.8);
+
+      // Draw count inside node
+      if (n.radius >= 14) {
+        ctx.font = `bold ${Math.max(9, fontSize - 2)}px system-ui, -apple-system, sans-serif`;
+        ctx.fillStyle = isHovered
+          ? "#ffffff"
+          : dark
+            ? "#7dd3fc"
+            : "#1e40af";
+        ctx.fillText(String(n.count), n.x, n.y);
+      }
+    }
+  }, []);
+
+  const tick = useCallback(() => {
+    const moving = simulate();
+    draw();
+    if (moving || draggingRef.current) {
+      animRef.current = requestAnimationFrame(tick);
+    }
+  }, [simulate, draw]);
+
+  // Resize handler
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+
+    const onResize = () => {
+      const rect = container.getBoundingClientRect();
+      sizeRef.current = { width: rect.width, height: rect.height };
+      draw();
+    };
+
+    const observer = new ResizeObserver(onResize);
+    observer.observe(container);
+    onResize();
+
+    return () => observer.disconnect();
+  }, [draw]);
+
+  // Start simulation
+  useEffect(() => {
+    let running = true;
+    let frame = 0;
+    const maxFrames = 500;
+
+    const loop = () => {
+      if (!running) return;
+      const moving = simulate();
+      draw();
+      frame++;
+      if ((moving || draggingRef.current) && frame < maxFrames) {
+        animRef.current = requestAnimationFrame(loop);
+      }
+    };
+
+    animRef.current = requestAnimationFrame(loop);
+
+    return () => {
+      running = false;
+      cancelAnimationFrame(animRef.current);
+    };
+  }, [simulate, draw]);
+
+  const getNodeAt = useCallback((x: number, y: number): TagNode | null => {
+    const ns = nodesRef.current;
+    for (let i = ns.length - 1; i >= 0; i--) {
+      const n = ns[i];
+      const dx = x - n.x;
+      const dy = y - n.y;
+      if (dx * dx + dy * dy <= (n.radius + 4) * (n.radius + 4)) {
+        return n;
+      }
+    }
+    return null;
+  }, []);
+
+  const getCanvasPos = useCallback(
+    (e: React.MouseEvent | React.TouchEvent) => {
+      const canvas = canvasRef.current;
+      if (!canvas) return { x: 0, y: 0 };
+      const rect = canvas.getBoundingClientRect();
+      const clientX =
+        "touches" in e ? e.touches[0].clientX : (e as React.MouseEvent).clientX;
+      const clientY =
+        "touches" in e ? e.touches[0].clientY : (e as React.MouseEvent).clientY;
+      return { x: clientX - rect.left, y: clientY - rect.top };
+    },
+    [],
+  );
+
+  const handlePointerDown = useCallback(
+    (e: React.MouseEvent) => {
+      const pos = getCanvasPos(e);
+      const node = getNodeAt(pos.x, pos.y);
+      if (node) {
+        draggingRef.current = node;
+        offsetRef.current = { x: pos.x - node.x, y: pos.y - node.y };
+        animRef.current = requestAnimationFrame(tick);
+      }
+    },
+    [getCanvasPos, getNodeAt, tick],
+  );
+
+  const handlePointerMove = useCallback(
+    (e: React.MouseEvent) => {
+      const pos = getCanvasPos(e);
+
+      if (draggingRef.current) {
+        draggingRef.current.x = pos.x - offsetRef.current.x;
+        draggingRef.current.y = pos.y - offsetRef.current.y;
+        return;
+      }
+
+      const node = getNodeAt(pos.x, pos.y);
+      const canvas = canvasRef.current;
+      if (canvas) {
+        canvas.style.cursor = node ? "pointer" : "default";
+      }
+
+      if (node !== hoveredRef.current) {
+        hoveredRef.current = node;
+        setHovered(node?.tag ?? null);
+        draw();
+      }
+    },
+    [getCanvasPos, getNodeAt, draw],
+  );
+
+  const handlePointerUp = useCallback(() => {
+    draggingRef.current = null;
+  }, []);
+
+  const handleClick = useCallback(
+    (e: React.MouseEvent) => {
+      const pos = getCanvasPos(e);
+      const node = getNodeAt(pos.x, pos.y);
+      if (node) {
+        router.push(`/${prefix}/tag/${node.tag}/1` as Route);
+      }
+    },
+    [getCanvasPos, getNodeAt, router, prefix],
+  );
+
+  return (
+    <div
+      ref={containerRef}
+      style={{ width: "100%", height: "70vh", minHeight: "400px" }}
+    >
+      <canvas
+        ref={canvasRef}
+        onMouseDown={handlePointerDown}
+        onMouseMove={handlePointerMove}
+        onMouseUp={handlePointerUp}
+        onMouseLeave={handlePointerUp}
+        onClick={handleClick}
+        style={{ display: "block", width: "100%", height: "100%" }}
+      />
+      {hovered && (
+        <div
+          style={{
+            position: "absolute",
+            bottom: "16px",
+            left: "50%",
+            transform: "translateX(-50%)",
+            padding: "6px 16px",
+            borderRadius: "9999px",
+            fontSize: "14px",
+            fontFamily: "system-ui, sans-serif",
+            pointerEvents: "none",
+            backgroundColor: "var(--colors-bg-surface, #fff)",
+            color: "var(--colors-text-primary, #0f172a)",
+            border: "1px solid var(--colors-border-default, #e2e8f0)",
+            boxShadow: "0 2px 8px rgba(0,0,0,0.1)",
+          }}
+        >
+          {hovered}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/features/articles/components/TagNetwork.tsx
+++ b/web/src/features/articles/components/TagNetwork.tsx
@@ -227,14 +227,15 @@ export default function TagNetwork({ nodes, edges, prefix }: TagNetworkProps) {
     }
 
     // Draw nodes
+    const hoveredTag = hoveredRef.current?.tag;
     for (const n of ns) {
       const isHovered = hoveredRef.current === n;
       const isConnected =
-        hoveredRef.current &&
+        hoveredTag != null &&
         es.some(
           (e) =>
-            (e.source === hoveredRef.current!.tag && e.target === n.tag) ||
-            (e.target === hoveredRef.current!.tag && e.source === n.tag),
+            (e.source === hoveredTag && e.target === n.tag) ||
+            (e.target === hoveredTag && e.source === n.tag),
         );
       const dimmed = hoveredRef.current && !isHovered && !isConnected;
 

--- a/web/src/features/articles/irepository.ts
+++ b/web/src/features/articles/irepository.ts
@@ -1,5 +1,21 @@
 import type { DumpPost, Lang } from "common";
 
+export interface TagNetworkNode {
+  tag: string;
+  count: number;
+}
+
+export interface TagNetworkEdge {
+  source: string;
+  target: string;
+  weight: number;
+}
+
+export interface TagNetworkData {
+  nodes: TagNetworkNode[];
+  edges: TagNetworkEdge[];
+}
+
 export interface IBlogRepository {
   retrieve: (uuid: string, lang?: Lang) => Promise<DumpPost | undefined>;
   list: () => Promise<DumpPost[]>;
@@ -10,4 +26,5 @@ export interface IBlogRepository {
     tag?: string,
     category?: string,
   ) => Promise<DumpPost[]>;
+  tagNetwork: (lang?: Lang) => Promise<TagNetworkData>;
 }

--- a/web/src/features/articles/repository/dump.ts
+++ b/web/src/features/articles/repository/dump.ts
@@ -4,7 +4,10 @@ import type { Dump, DumpPost, Lang } from "common";
 import { readDump } from "common/io";
 import * as R from "remeda";
 
-import type { IBlogRepository as IBlogRepository } from "../irepository";
+import type {
+  IBlogRepository as IBlogRepository,
+  TagNetworkData,
+} from "../irepository";
 
 export default class DumpRepository implements IBlogRepository {
   path: PathLike;
@@ -74,5 +77,42 @@ export default class DumpRepository implements IBlogRepository {
     };
 
     return dump.posts.filter((post) => checkPost(post, lang, tag, category));
+  }
+
+  async tagNetwork(lang?: Lang): Promise<TagNetworkData> {
+    const dump = await this.get_dump();
+    const excludedTags = new Set(["archive", "draft"]);
+
+    const posts = lang
+      ? dump.posts.filter((p) => p.meta.lang === lang)
+      : dump.posts;
+
+    const tagCount = new Map<string, number>();
+    const edgeMap = new Map<string, number>();
+
+    for (const post of posts) {
+      const tags = post.meta.tags.filter((t) => !excludedTags.has(t));
+      for (const tag of tags) {
+        tagCount.set(tag, (tagCount.get(tag) ?? 0) + 1);
+      }
+      for (let i = 0; i < tags.length; i++) {
+        for (let j = i + 1; j < tags.length; j++) {
+          const key = [tags[i], tags[j]].sort().join("\0");
+          edgeMap.set(key, (edgeMap.get(key) ?? 0) + 1);
+        }
+      }
+    }
+
+    const nodes = [...tagCount.entries()].map(([tag, count]) => ({
+      tag,
+      count,
+    }));
+
+    const edges = [...edgeMap.entries()].map(([key, weight]) => {
+      const [source, target] = key.split("\0");
+      return { source, target, weight };
+    });
+
+    return { nodes, edges };
   }
 }

--- a/web/src/features/articles/service.test.ts
+++ b/web/src/features/articles/service.test.ts
@@ -35,6 +35,7 @@ function makeRepo(posts: DumpPost[]): IBlogRepository {
     categories: async () => [],
     tags: async () => [],
     filterPosts: async () => posts,
+    tagNetwork: async () => ({ nodes: [], edges: [] }),
   };
 }
 

--- a/web/src/lib/i18n/dictionaries/en.ts
+++ b/web/src/lib/i18n/dictionaries/en.ts
@@ -31,6 +31,9 @@ const en: Dictionary = {
     tagList: (prefix: string) => `${prefix} Tags`,
     tagListDescription: (prefix: string) =>
       `List of tags used in ${prefix} articles on illumination-k.dev`,
+    tagNetwork: (prefix: string) => `${prefix} Tag Network`,
+    tagNetworkDescription: (prefix: string) =>
+      `Tag co-occurrence network for ${prefix} articles on illumination-k.dev`,
   },
   search: {
     placeholder: "Search articles...",

--- a/web/src/lib/i18n/dictionaries/es.ts
+++ b/web/src/lib/i18n/dictionaries/es.ts
@@ -31,6 +31,9 @@ const es: Dictionary = {
     tagList: (prefix: string) => `${prefix} Etiquetas`,
     tagListDescription: (prefix: string) =>
       `Lista de etiquetas de artículos de ${prefix} en illumination-k.dev`,
+    tagNetwork: (prefix: string) => `${prefix} Red de Etiquetas`,
+    tagNetworkDescription: (prefix: string) =>
+      `Red de co-ocurrencia de etiquetas de artículos de ${prefix} en illumination-k.dev`,
   },
   search: {
     placeholder: "Buscar artículos...",

--- a/web/src/lib/i18n/dictionaries/ja.ts
+++ b/web/src/lib/i18n/dictionaries/ja.ts
@@ -35,6 +35,9 @@ const ja: Dictionary = {
     tagList: (prefix: string) => `${prefix} タグ一覧`,
     tagListDescription: (prefix: string) =>
       `illumination-k.dev の${prefix}記事に付けられたタグの一覧`,
+    tagNetwork: (prefix: string) => `${prefix} タグネットワーク`,
+    tagNetworkDescription: (prefix: string) =>
+      `illumination-k.dev の${prefix}記事のタグ共起ネットワーク`,
   },
   // Search
   search: {

--- a/web/src/lib/i18n/types.ts
+++ b/web/src/lib/i18n/types.ts
@@ -29,6 +29,8 @@ export interface Dictionary {
     tagArticleListDescription: (tag: string, page: number | string) => string;
     tagList: (prefix: string) => string;
     tagListDescription: (prefix: string) => string;
+    tagNetwork: (prefix: string) => string;
+    tagNetworkDescription: (prefix: string) => string;
   };
   search: {
     placeholder: string;


### PR DESCRIPTION
Introduce an interactive force-directed graph page at
/[locale]/techblog/tag/network that visualizes tag relationships.
Tags that appear together on the same post are connected by edges,
with node size reflecting post count and edge thickness reflecting
co-occurrence frequency. Built with Canvas API (no external deps).
Hover highlights connected subgraph; click navigates to the tag page.

- Add tagNetwork() to IBlogRepository/DumpRepository
- Add TagNetwork client component (force-directed layout on Canvas)
- Add i18n entries for ja/en/es
- Add navigation link from tag list page to network view

https://claude.ai/code/session_01TNzFYSeKQv4gbm2wAGsfc5