### PR TITLE
Fix directive embed syntax in README and techblog-writing skill

### DIFF
--- a/.claude/skills/techblog-writing/SKILL.md
+++ b/.claude/skills/techblog-writing/SKILL.md
@@ -73,7 +73,7 @@ illumination-k.dev の技術ブログ記事を執筆・編集する。
 ### 1. 雛形の生成
 
 ```bash
-pnpm cli template -o posts/techblog/{category}/{filename}.md --tags ai-generated --tags {proper tags}
+pnpm cli template -o posts/techblog/ja/{category}/{filename}.md --tags ai-generated --tags {proper tags}
 ```
 
 `ai-generated` タグは必ず入れる。その他のタグは内容に応じて適切に選ぶ。
@@ -99,12 +99,15 @@ title, description, category, tagsを埋める。descriptionは検索結果やOG
 記事の執筆・編集後は、必ずtextlintを実行する。エラーがあれば修正し、エラーがなくなるまで繰り返す。
 
 ```bash
-npx textlint posts/techblog/{category}/{filename}.md
+npx textlint posts/techblog/ja/{category}/{filename}.md
 ```
 
 ### 6. cli lint検証（必須）
 
-レンダリングされない強調（`**...**`や`*...*`がテキストのまま残る問題）を検出するため、cli lintを実行する。エラーがあれば修正する。典型的な原因は`**`の前後にスペースが必要なケース。
+cli lintを実行する。エラーがあれば修正する。検出される主な問題は2種類:
+
+- **レンダリングされない強調** — `**...**`や`*...*`がテキストのまま残る問題。典型的な原因は`**`の前後にスペースが必要なケース。
+- **SEO metaの文字数** — front-matterの`title`・`description`が想定範囲外だとエラーになる。日本語記事（`lang: ja`）の範囲は `title` 15〜60文字、`description` 50〜160文字。
 
 ```bash
 pnpm cli:build && pnpm cli lint --src posts
@@ -114,11 +117,31 @@ pnpm cli:build && pnpm cli lint --src posts
 
 - 標準Markdown（見出し、リスト、コードブロック、リンク、画像）
 - KaTeX数式（`$inline$` / `$$block$$`）
-- GitHub埋め込み: `::gh[https://github.com/...]`
-- 図表: `::figure[caption]{src="image.png"}`
-- 折りたたみ: `:::details` / `:::`
+- Mermaid図（`` ```mermaid `` コードブロック）
 - コードブロックのタイトル: `` ```lang title=filename ``
+- GitHub埋め込み（いずれもリーフディレクティブ `::`）:
+  - `::gh[https://github.com/owner/repo/blob/.../file#L1-L10]` — ファイル/パーマリンクの埋め込み
+  - `::gh-card[owner/repo]` — リポジトリカード
+  - `::gh-meta[owner/repo]` — スター数・更新日などのメタ情報をインライン表示
+- YouTube埋め込み: `::youtube[VIDEO_ID]`
+- 論文埋め込み: `::doi[10.xxxx/...]`
+- 書籍埋め込み: `::isbn[ISBN]`（ISBN-10 / ISBN-13）
 - ファイル埋め込み: `::file[./relative/path]` — 記事と同階層の companion ディレクトリ内ファイルを記事本文にコードブロックとして差し込む。詳細は下記「再現性のためのcompanionディレクトリ」を参照
+- 図表（コンテナディレクティブ `:::`。`Figure N: caption` のキャプションが自動で付く）:
+
+  ```markdown
+  :::figure[キャプション]
+  ![alt](image.png)
+  :::
+  ```
+
+- 折りたたみ（コンテナディレクティブ `:::`。ラベルが`<summary>`になる。省略時は `Details`）:
+
+  ```markdown
+  :::details[サマリ]
+  本文
+  :::
+  ```
 
 ### 7. セルフレビュー
 

--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ reproducible.
   (filtered by `Status=Done`) via `pnpm cli paper-stream`, then rendered
   alongside the techblog.
 - **Rich Markdown, not plain Markdown.** A small collection of directive-based
-  embeds — `:::github`, `:::github-card`, `:::youtube`, `:::doi`, `:::book`,
-  `:::file`, plus `:::details` and `:::figure` containers — makes posts feel
+  embeds — `::gh`, `::gh-card`, `::gh-meta`, `::youtube`, `::doi`, `::isbn`,
+  `::file`, plus `:::details` and `:::figure` containers — makes posts feel
   alive without leaving MDX. Code blocks get titles, headings get anchor IDs,
   math renders with KaTeX, diagrams with Mermaid, code with Prism.
 - **Automatic OG images.** Every post gets a per-title social card generated
@@ -59,7 +59,7 @@ reproducible.
 
 ```
 web/        Next.js 16 app (App Router, static export)
-cli/        post-utils CLI (dump, og, rss, template, lint, orcid, …)
+cli/        post-utils CLI (dump, dump-file, og, rss, template, migration, lint, orcid, paper-stream)
 packages/
   common/       Shared Zod schemas & types
   md-plugins/   remark / rehype plugins + embed transformers


### PR DESCRIPTION
Align documented directive embeds with the actual md-plugins
implementation: leaf directives use `::` (not `:::`), and the
real names are `gh`/`gh-card`/`gh-meta`/`isbn` rather than
`github`/`github-card`/`book`. Also correct post paths to include
the `{lang}` segment and document the cli lint SEO meta checks.

https://claude.ai/code/session_01DhhdUG1dhKui4AjtyRics4