### PR TITLE
Exit the CLI once a command completes instead of waiting for the loop to drain

### DIFF
--- a/.github/workflows/web-build.yaml
+++ b/.github/workflows/web-build.yaml
@@ -5,6 +5,8 @@ on:
     paths:
       - "web/**"
       - posts/**
+      - "cli/**"
+      - "packages/**"
       - ".github/workflows/web-build.yaml"
   push:
     branches:
@@ -12,6 +14,8 @@ on:
     paths:
       - "web/**"
       - posts/**
+      - "cli/**"
+      - "packages/**"
       - ".github/workflows/web-build.yaml"
 
 permissions:

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -17,6 +17,28 @@ import { template } from "./template";
 // with code 0 and downstream steps fail later with confusing errors.
 let pendingCommand: string | null = null;
 
+// Embed fetches that hit their deadline are abandoned rather than aborted
+// (aborting corrupts undici's connection pool), so their sockets can stay open
+// long after the command's work is done. Observed in CI as a dump that wrote
+// its JSON and then sat for 28 minutes until the job timed out. Once a command
+// has completed there is nothing left to wait for, so flush the logs and exit
+// instead of waiting for the event loop to drain.
+async function exitAfterFlush(): Promise<void> {
+  await new Promise<void>((resolve) => {
+    let settled = false;
+    const done = () => {
+      if (settled) return;
+      settled = true;
+      resolve();
+    };
+    // The pino transport writes from a worker thread; bound the wait so a
+    // transport that never reports back cannot reintroduce the hang.
+    setTimeout(done, 2_000);
+    logger.flush(done);
+  });
+  process.exit(process.exitCode ?? 0);
+}
+
 function guarded(
   name: string,
   handler: (argv: ArgumentsCamelCase) => Promise<void>,
@@ -28,6 +50,7 @@ function guarded(
     } finally {
       pendingCommand = null;
     }
+    await exitAfterFlush();
   };
 }
 

--- a/web/src/data/metrics-history.ndjson
+++ b/web/src/data/metrics-history.ndjson
@@ -24,4 +24,4 @@
 {"date":"2026-04-16","sha":"ce4b2bb","pr":166,"coverage":{"lines":61.9,"statements":61.46,"functions":62.06,"branches":54.57},"mutation":{"score":45.92,"killed":1581,"survived":1870,"timeout":7,"noCoverage":0,"total":3458}}
 {"date":"2026-08-01","sha":"87cdf39","pr":173,"coverage":{"lines":61.98,"statements":61.48,"functions":62.23,"branches":54.57},"mutation":{"score":45.94,"killed":1597,"survived":746,"timeout":8,"noCoverage":1143,"total":3494}}
 {"date":"2026-08-01","sha":"08dd49a","pr":172,"coverage":{"lines":59.46,"statements":58.79,"functions":57.81,"branches":50.58},"mutation":{"score":45.94,"killed":1597,"survived":746,"timeout":8,"noCoverage":1143,"total":3494}}
-{"date":"2026-08-01","sha":"d18fc3d","pr":174,"coverage":{"lines":59.46,"statements":58.79,"functions":57.81,"branches":50.58},"mutation":{"score":45.83,"killed":1597,"survived":746,"timeout":8,"noCoverage":1151,"total":3502}}
+{"date":"2026-08-01","sha":"eae9638","pr":174,"coverage":{"lines":59.46,"statements":58.79,"functions":57.81,"branches":50.58},"mutation":{"score":45.83,"killed":1597,"survived":746,"timeout":8,"noCoverage":1151,"total":3502}}

--- a/web/src/data/metrics-history.ndjson
+++ b/web/src/data/metrics-history.ndjson
@@ -24,3 +24,4 @@
 {"date":"2026-04-16","sha":"ce4b2bb","pr":166,"coverage":{"lines":61.9,"statements":61.46,"functions":62.06,"branches":54.57},"mutation":{"score":45.92,"killed":1581,"survived":1870,"timeout":7,"noCoverage":0,"total":3458}}
 {"date":"2026-08-01","sha":"87cdf39","pr":173,"coverage":{"lines":61.98,"statements":61.48,"functions":62.23,"branches":54.57},"mutation":{"score":45.94,"killed":1597,"survived":746,"timeout":8,"noCoverage":1143,"total":3494}}
 {"date":"2026-08-01","sha":"08dd49a","pr":172,"coverage":{"lines":59.46,"statements":58.79,"functions":57.81,"branches":50.58},"mutation":{"score":45.94,"killed":1597,"survived":746,"timeout":8,"noCoverage":1143,"total":3494}}
+{"date":"2026-08-01","sha":"d18fc3d","pr":174,"coverage":{"lines":59.46,"statements":58.79,"functions":57.81,"branches":50.58},"mutation":{"score":45.83,"killed":1597,"survived":746,"timeout":8,"noCoverage":1151,"total":3502}}


### PR DESCRIPTION
## 問題

#172 のマージ後、main の web build が [30706424768](https://github.com/illumination-k/site/actions/runs/30706424768/job/91386234830) でジョブタイムアウトしました。ログを見ると paperStream の dump は正常に完走していて、出力 JSON も書き終わっています。

```
15:42:37 INFO: Dump complete  count: 5  output: ./web/dump/paperStream.json
16:10:29 ##[error]The operation was canceled.
```

「Dump complete」から28分間、何も起きずにプロセスが生き続けていました（cancel 時に dump の node プロセスが orphan として kill されている）。やるべき仕事は終わっているのに、イベントループが空にならず終了できていない状態です。

## 原因

`fetchWithRetry` はデッドラインに達した fetch を abort せず放置します（abort すると undici のコネクションプールが壊れるため、意図的にそうしている）。放置されたソケットは開いたままイベントループを掴み続けるので、コマンド本体が完了してもプロセスが終了しません。到達不能な embed ホストに当たるかどうか次第なので、症状は間欠的です。

## 対応

`guarded()` でラップされたコマンドが正常終了したら、ログをフラッシュして明示的に `process.exit` します。この時点で待つべきものは何もありません。pino のトランスポートはワーカースレッドで書き出すため、フラッシュ待ちには2秒の上限を設けて、トランスポート側の詰まりがハングを再発させないようにしています。

異常系（`.fail()`）の終了経路は既存のまま触っていません。

## 確認

- `pnpm lint` / `pnpm test` パス
- `pnpm cli:dump:techblog` をローカル実行し、最後の「Dump complete」行まで出力された上で即座に exit 0 することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)