### PR TITLE
Fix SEO defects found auditing the exported site

### DIFF
--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -217,7 +217,8 @@ yargs(hideBin(process.argv))
     },
   )
   .command(
-    "migration",
+    // Same positional binding as `lint` — see the note there.
+    "migration <src>",
     "migration utils",
     (yargs) => {
       yargs.positional("src", { type: "string", describe: "posts src" });
@@ -229,7 +230,10 @@ yargs(hideBin(process.argv))
     }),
   )
   .command(
-    "lint",
+    // `<src>` has to be in the command string for yargs to bind the positional;
+    // without it `post-utils lint ./posts/techblog` failed `demandOption` and
+    // exited with "Invalid usage", so the SEO meta lint could never run.
+    "lint <src>",
     "Lint markdown posts for common issues",
     (yargs) => {
       yargs.positional("src", {

--- a/posts/paperStream/13a562eb-ad81-8036-a60b-e301b9c65456.md
+++ b/posts/paperStream/13a562eb-ad81-8036-a60b-e301b9c65456.md
@@ -2,7 +2,7 @@
 uuid: 13a562eb-ad81-8036-a60b-e301b9c65456
 title: Personal transcriptome variation is poorly explained by current genomic
   deep learning models
-description: ""
+description: Enformer・Basenji2・ExPecto・Xpresso の4つの深層学習モデルが、個人のゲノム配列から個人ごとの遺伝子発現量の違いを予測できるかを、1000 Genomes と LCL の RNA-seq のペアで検証した論文のまとめ。
 category: paper-stream
 tags:
   - nature genetics

--- a/web/src/app/[locale]/(articles)/_factory/pagerFactory.tsx
+++ b/web/src/app/[locale]/(articles)/_factory/pagerFactory.tsx
@@ -112,11 +112,18 @@ export default class PagerFactory {
       const { page, locale: localeParam } = params;
       const locale: Locale = isLocale(localeParam) ? localeParam : "ja";
       const lang = localeToLang(locale);
-      const posts = await this.blogService.repo.filterPosts(lang);
+      const [posts, dict] = await Promise.all([
+        this.blogService.repo.filterPosts(lang),
+        getDictionary(locale),
+      ]);
       const pageInformation = pager.getPageInformation(
         posts.map((p) => p.meta),
         page,
       );
+      const heading =
+        page === 1
+          ? dict.meta.articleList(this.prefix)
+          : dict.meta.articleListPage(this.prefix, page);
 
       return (
         <div
@@ -133,6 +140,7 @@ export default class PagerFactory {
               lg: { gridColumnStart: "3", gridColumnEnd: "11" },
             })}
             prefix={`${locale}/${this.prefix}`}
+            heading={heading}
             pageInformation={pageInformation}
             pageLinkGenerator={(page) =>
               `/${locale}/${this.prefix}/${page}` as Route

--- a/web/src/app/[locale]/(articles)/_factory/tagFactory.tsx
+++ b/web/src/app/[locale]/(articles)/_factory/tagFactory.tsx
@@ -128,11 +128,18 @@ export class TagPagerFactory {
       const { page, tag, locale: localeParam } = params;
       const locale: Locale = isLocale(localeParam) ? localeParam : "ja";
       const lang = localeToLang(locale);
-      const posts = await this.blogService.repo.filterPosts(lang, tag);
+      const [posts, dict] = await Promise.all([
+        this.blogService.repo.filterPosts(lang, tag),
+        getDictionary(locale),
+      ]);
       const pageInformation = pager.getPageInformation(
         posts.map((p) => p.meta),
         page,
       );
+      const heading =
+        page === 1
+          ? dict.meta.tagArticleList(tag)
+          : dict.meta.tagArticleListPage(tag, page);
 
       return (
         <div
@@ -149,6 +156,7 @@ export class TagPagerFactory {
               lg: { gridColumnStart: "3", gridColumnEnd: "11" },
             })}
             prefix={`${locale}/${this.prefix}`}
+            heading={heading}
             pageInformation={pageInformation}
             pageLinkGenerator={(page) =>
               `/${locale}/${this.prefix}/tag/${tag}/${page}` as Route
@@ -211,10 +219,21 @@ export class TagTopPageFactory {
           <div
             className={css({
               display: "flex",
-              justifyContent: "flex-end",
+              justifyContent: "space-between",
+              alignItems: "center",
+              gap: 4,
               mb: 4,
             })}
           >
+            <h1
+              className={css({
+                fontSize: { base: "xl", md: "2xl" },
+                fontWeight: "bold",
+                color: "text.primary",
+              })}
+            >
+              {dict.meta.tagList(this.prefix)}
+            </h1>
             <Link
               href={`/${locale}/${this.prefix}/tag/network` as Route}
               className={css({

--- a/web/src/app/[locale]/(articles)/_factory/tagNetworkFactory.tsx
+++ b/web/src/app/[locale]/(articles)/_factory/tagNetworkFactory.tsx
@@ -1,0 +1,126 @@
+import { css } from "@/styled-system/css";
+
+import type { Metadata } from "next";
+
+import TagNetwork from "@/features/articles/components/TagNetwork";
+import type BlogService from "@/features/articles/service";
+import { type Locale, getDictionary, isLocale, localeToLang } from "@/lib/i18n";
+import { buildAlternates } from "@/lib/seo";
+import { SITE_URL } from "@/lib/site";
+
+interface Props {
+  params: Promise<{ locale: string }>;
+}
+
+/**
+ * Tag co-occurrence network page. Every article prefix whose tag index links to
+ * `${prefix}/tag/network` needs a route built from this factory, otherwise that
+ * link resolves to a 404.
+ */
+export default class TagNetworkPageFactory {
+  private blogService: BlogService;
+  private prefix: string;
+
+  constructor(prefix: string, blogService: BlogService) {
+    this.prefix = prefix;
+    this.blogService = blogService;
+  }
+
+  public createGenerateMetadataFn() {
+    return async ({ params }: Props): Promise<Metadata> => {
+      const { locale: localeParam } = await params;
+      const locale: Locale = isLocale(localeParam) ? localeParam : "ja";
+      const dict = await getDictionary(locale);
+
+      const title = dict.meta.tagNetwork(this.prefix);
+      const description = dict.meta.tagNetworkDescription(this.prefix);
+
+      return {
+        title,
+        description,
+        alternates: buildAlternates({
+          canonicalLocale: locale,
+          buildPath: (l) => `/${l}/${this.prefix}/tag/network`,
+        }),
+        openGraph: {
+          title,
+          description,
+          url: `${SITE_URL}/${locale}/${this.prefix}/tag/network`,
+        },
+      };
+    };
+  }
+
+  public createPage() {
+    const prefix = this.prefix;
+    const blogService = this.blogService;
+
+    const TagNetworkPage = async ({
+      params, // eslint-disable-line react/prop-types
+    }: Props) => {
+      const { locale: localeParam } = await params;
+      const locale: Locale = isLocale(localeParam) ? localeParam : "ja";
+      const lang = localeToLang(locale);
+      const dict = await getDictionary(locale);
+
+      const networkData = await blogService.repo.tagNetwork(lang);
+
+      return (
+        <div
+          className={css({
+            bg: "bg.page",
+            display: "grid",
+            gridTemplateColumns: "repeat(12, minmax(0, 1fr))",
+          })}
+        >
+          <div
+            className={css({
+              gridColumnStart: "1",
+              gridColumnEnd: "-1",
+              lg: { gridColumnStart: "2", gridColumnEnd: "12" },
+              p: 4,
+            })}
+          >
+            <h1
+              className={css({
+                fontSize: "2xl",
+                fontWeight: "bold",
+                color: "text.primary",
+                mb: 2,
+              })}
+            >
+              {dict.meta.tagNetwork(prefix)}
+            </h1>
+            <p
+              className={css({
+                fontSize: "sm",
+                color: "text.secondary",
+                mb: 4,
+              })}
+            >
+              {dict.meta.tagNetworkDescription(prefix)}
+            </p>
+            <div
+              className={css({
+                bg: "bg.surface",
+                borderRadius: "xl",
+                border: "1px solid",
+                borderColor: "border.default",
+                overflow: "hidden",
+                position: "relative",
+              })}
+            >
+              <TagNetwork
+                nodes={networkData.nodes}
+                edges={networkData.edges}
+                prefix={`${locale}/${prefix}`}
+              />
+            </div>
+          </div>
+        </div>
+      );
+    };
+
+    return TagNetworkPage;
+  }
+}

--- a/web/src/app/[locale]/(articles)/paperstream/tag/network/page.tsx
+++ b/web/src/app/[locale]/(articles)/paperstream/tag/network/page.tsx
@@ -1,8 +1,8 @@
-import { blogService } from "@/features/techblog/constant";
+import { paperStreamService } from "@/features/paperStream/constants";
 
 import TagNetworkPageFactory from "../../../_factory/tagNetworkFactory";
 
-const factory = new TagNetworkPageFactory("techblog", blogService);
+const factory = new TagNetworkPageFactory("paperstream", paperStreamService);
 
 export const generateMetadata = factory.createGenerateMetadataFn();
 

--- a/web/src/app/[locale]/disclaimer/page.tsx
+++ b/web/src/app/[locale]/disclaimer/page.tsx
@@ -19,7 +19,9 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const locale: Locale = isLocale(localeParam) ? localeParam : "ja";
   const dict = await getDictionary(locale);
   return {
-    title: `${dict.disclaimer.title} | illumination-k.dev`,
+    // The [locale] layout's title template already appends
+    // " | illumination-k.dev"; repeating it here doubled the suffix.
+    title: dict.disclaimer.title,
     description: `illumination-k.dev ${dict.disclaimer.title}`,
     alternates: buildAlternates({
       canonicalLocale: locale,

--- a/web/src/app/[locale]/privacy-policy/page.tsx
+++ b/web/src/app/[locale]/privacy-policy/page.tsx
@@ -19,7 +19,9 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const locale: Locale = isLocale(localeParam) ? localeParam : "ja";
   const dict = await getDictionary(locale);
   return {
-    title: `${dict.privacyPolicy.title} | illumination-k.dev`,
+    // The [locale] layout's title template already appends
+    // " | illumination-k.dev"; repeating it here doubled the suffix.
+    title: dict.privacyPolicy.title,
     description: `illumination-k.dev ${dict.privacyPolicy.title}`,
     alternates: buildAlternates({
       canonicalLocale: locale,

--- a/web/src/app/page.test.tsx
+++ b/web/src/app/page.test.tsx
@@ -1,14 +1,23 @@
-import { redirect } from "next/navigation";
+import { render } from "@testing-library/react";
+import { expect, test } from "vitest";
 
-import { expect, test, vi } from "vitest";
+import Page, { metadata } from "./page";
 
-vi.mock("next/navigation", () => ({
-  redirect: vi.fn(),
-}));
+test("root page points visitors at the default locale", () => {
+  const { container } = render(<Page />);
 
-import Page from "./page";
+  // React hoists document metadata out of the component tree into <head>.
+  const refresh = document.head.querySelector('meta[http-equiv="refresh"]');
+  expect(refresh?.getAttribute("content")).toBe("0; url=/ja");
+  expect(container.querySelector("a")?.getAttribute("href")).toBe("/ja");
+});
 
-test("root page redirects to default locale", () => {
-  Page();
-  expect(redirect).toHaveBeenCalledWith("/ja");
+test("root page canonicalises to the default locale homepage", () => {
+  expect(metadata.alternates?.canonical).toBe("https://illumination-k.dev/ja");
+  expect(metadata.alternates?.languages).toEqual({
+    ja: "https://illumination-k.dev/ja",
+    en: "https://illumination-k.dev/en",
+    es: "https://illumination-k.dev/es",
+    "x-default": "https://illumination-k.dev/ja",
+  });
 });

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -1,7 +1,57 @@
-import { redirect } from "next/navigation";
+import type { Metadata } from "next";
 
-import { defaultLocale } from "@/lib/i18n";
+import { defaultLocale, locales } from "@/lib/i18n";
+import { absoluteUrl } from "@/lib/seo";
+import { SITE_URL } from "@/lib/site";
+
+/**
+ * Entry page for the bare origin.
+ *
+ * `redirect()` cannot be used here: the site is a static export, so there is no
+ * server to issue the 3xx. Next.js emits the redirect as a runtime error shell
+ * — an `<html id="__next_error__">` document with no title, no description and
+ * no content — that only resolves once React hydrates. Crawlers fetching
+ * `https://illumination-k.dev/` see that empty shell, which is the worst
+ * possible first impression for the origin most inbound links point at.
+ *
+ * Instead this renders a real document that says where the content lives:
+ * a canonical pointing at the default locale, hreflang for every locale, and a
+ * zero-delay meta refresh (plus a plain link) to move visitors along.
+ */
+const DEFAULT_LOCALE_PATH = `/${defaultLocale}`;
+
+export const metadata: Metadata = {
+  metadataBase: new URL(SITE_URL),
+  title: "illumination-k.dev",
+  description: "Software Engineer / Bioinformatics",
+  alternates: {
+    // The origin is not a page in its own right — it is an alias of the default
+    // locale homepage, so hand all of its signals to that URL.
+    canonical: absoluteUrl(DEFAULT_LOCALE_PATH),
+    languages: {
+      ...Object.fromEntries(locales.map((l) => [l, absoluteUrl(`/${l}`)])),
+      "x-default": absoluteUrl(DEFAULT_LOCALE_PATH),
+    },
+  },
+};
 
 export default function RootPage() {
-  redirect(`/${defaultLocale}`);
+  return (
+    <>
+      {/* React hoists this into <head>; browsers and crawlers both treat a
+          zero-delay refresh as a redirect to the default locale. */}
+      <meta httpEquiv="refresh" content={`0; url=${DEFAULT_LOCALE_PATH}`} />
+      <main
+        style={{
+          minHeight: "100vh",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          fontFamily: "system-ui, sans-serif",
+        }}
+      >
+        <a href={DEFAULT_LOCALE_PATH}>illumination-k.dev</a>
+      </main>
+    </>
+  );
 }

--- a/web/src/app/sitemap.test.ts
+++ b/web/src/app/sitemap.test.ts
@@ -75,9 +75,15 @@ const shared = vi.hoisted(() => {
         tags: ["go"],
         updated_at: "2024-03-01",
       }),
+      // Tag containing a space — used to verify <loc> values are URL-encoded.
+      makePost("TB-JA-EXT", {
+        lang: "ja",
+        tags: ["chrome extension"],
+        updated_at: "2024-03-02",
+      }),
     ],
     categories: ["techblog"],
-    tags: ["rust", "go"],
+    tags: ["rust", "go", "chrome extension"],
   };
 
   const PAPERSTREAM_DUMP: Dump = {
@@ -134,11 +140,13 @@ import sitemap from "./sitemap";
 const BASE = "https://illumination-k.dev";
 
 describe("sitemap", () => {
-  it("includes the site root and per-locale homepages", async () => {
+  it("includes the per-locale homepages but not the bare origin", async () => {
     const entries = await sitemap();
     const urls = entries.map((e) => e.url);
 
-    expect(urls).toContain(BASE);
+    // The origin only redirects to /ja and canonicalises there, so listing it
+    // would advertise a non-canonical URL.
+    expect(urls).not.toContain(BASE);
     expect(urls).toContain(`${BASE}/ja`);
     expect(urls).toContain(`${BASE}/en`);
     expect(urls).toContain(`${BASE}/es`);
@@ -155,12 +163,14 @@ describe("sitemap", () => {
     }
   });
 
-  it("includes the tag network page for every locale", async () => {
+  it("includes the tag network page for every locale and prefix", async () => {
     const entries = await sitemap();
     const urls = new Set(entries.map((e) => e.url));
 
     for (const locale of ["ja", "en", "es"]) {
-      expect(urls.has(`${BASE}/${locale}/techblog/tag/network`)).toBe(true);
+      for (const prefix of ["techblog", "paperstream"]) {
+        expect(urls.has(`${BASE}/${locale}/${prefix}/tag/network`)).toBe(true);
+      }
     }
   });
 
@@ -196,28 +206,37 @@ describe("sitemap", () => {
     expect(urls.has(`${BASE}/ja/paperstream/2`)).toBe(false);
   });
 
-  it("lists every unique post UUID across all languages for every locale", async () => {
+  it("lists each post only at the locale that owns its language", async () => {
     const entries = await sitemap();
     const urls = new Set(entries.map((e) => e.url));
 
-    for (const locale of ["ja", "en", "es"]) {
-      // en-only post is still emitted for all locales.
-      expect(urls.has(`${BASE}/${locale}/techblog/post/TB-EN-ONLY`)).toBe(true);
-      // ja-only post with the "go" tag is also present everywhere.
-      expect(urls.has(`${BASE}/${locale}/techblog/post/TB-JA-GO`)).toBe(true);
-      // Shared post appears once per locale.
-      expect(urls.has(`${BASE}/${locale}/techblog/post/TB-JA-RUST-1`)).toBe(
-        true,
-      );
-    }
+    // en-only post: /en only. The /ja and /es copies exist as static files but
+    // canonicalise to /en, so they must stay out of the sitemap.
+    expect(urls.has(`${BASE}/en/techblog/post/TB-EN-ONLY`)).toBe(true);
+    expect(urls.has(`${BASE}/ja/techblog/post/TB-EN-ONLY`)).toBe(false);
+    expect(urls.has(`${BASE}/es/techblog/post/TB-EN-ONLY`)).toBe(false);
+
+    // ja-only post: /ja only.
+    expect(urls.has(`${BASE}/ja/techblog/post/TB-JA-GO`)).toBe(true);
+    expect(urls.has(`${BASE}/en/techblog/post/TB-JA-GO`)).toBe(false);
+    expect(urls.has(`${BASE}/es/techblog/post/TB-JA-GO`)).toBe(false);
+
+    // Post translated into ja and en: both translations are canonical.
+    expect(urls.has(`${BASE}/ja/techblog/post/TB-JA-RUST-1`)).toBe(true);
+    expect(urls.has(`${BASE}/en/techblog/post/TB-JA-RUST-1`)).toBe(true);
+    expect(urls.has(`${BASE}/es/techblog/post/TB-JA-RUST-1`)).toBe(false);
   });
 
-  it("picks the most recent updated_at across languages for lastModified", async () => {
+  it("uses each translation's own updated_at for lastModified", async () => {
     const entries = await sitemap();
-    const shared = entries.find(
-      (e) => e.url === `${BASE}/ja/techblog/post/TB-JA-RUST-1`,
+    const byUrl = new Map(entries.map((e) => [e.url, e.lastModified]));
+
+    expect(byUrl.get(`${BASE}/ja/techblog/post/TB-JA-RUST-1`)).toBe(
+      "2024-02-01",
     );
-    expect(shared?.lastModified).toBe("2024-06-01");
+    expect(byUrl.get(`${BASE}/en/techblog/post/TB-JA-RUST-1`)).toBe(
+      "2024-06-01",
+    );
   });
 
   it("generates tag pagination per-locale and skips locales with no tagged posts", async () => {
@@ -245,6 +264,14 @@ describe("sitemap", () => {
     // Default tags (archive/draft) have no posts → no per-tag pages.
     expect(urls.has(`${BASE}/ja/techblog/tag/archive/1`)).toBe(false);
     expect(urls.has(`${BASE}/ja/techblog/tag/draft/1`)).toBe(false);
+  });
+
+  it("percent-encodes tags that are not URL-safe", async () => {
+    const entries = await sitemap();
+    const urls = new Set(entries.map((e) => e.url));
+
+    expect(urls.has(`${BASE}/ja/techblog/tag/chrome%20extension/1`)).toBe(true);
+    expect(urls.has(`${BASE}/ja/techblog/tag/chrome extension/1`)).toBe(false);
   });
 
   it("does not emit duplicate URLs", async () => {

--- a/web/src/app/sitemap.ts
+++ b/web/src/app/sitemap.ts
@@ -3,18 +3,17 @@ import type { MetadataRoute } from "next";
 import pager from "@/features/articles/utils/pager";
 import { paperStreamService } from "@/features/paperStream/constants";
 import { blogService } from "@/features/techblog/constant";
-import { localeToLang, locales } from "@/lib/i18n";
+import { langToLocale, localeToLang, locales } from "@/lib/i18n";
 import { SITE_URL } from "@/lib/site";
 
 export const dynamic = "force-static";
 
 const BASE_URL = SITE_URL;
 
-const STATIC_PATHS = [
-  "disclaimer",
-  "privacy-policy",
-  "profile",
-] as const;
+const STATIC_PATHS = ["disclaimer", "privacy-policy", "profile"] as const;
+
+/** Article prefixes that ship a `/tag/network` page. */
+const TAG_NETWORK_PREFIXES = ["techblog", "paperstream"] as const;
 
 async function generatePaginationSitemap(
   prefix: string,
@@ -51,9 +50,14 @@ async function generateTagSitemap(
       for (const tag of tags) {
         const taggedPosts = await service.repo.filterPosts(lang, tag);
         const totalPage = pager.getTotalPage(taggedPosts);
+        // Tags may contain characters that are not legal in a URL path — e.g.
+        // "chrome extension". Next writes `url` into <loc> verbatim, so an
+        // unencoded space makes the entry an invalid URL that also disagrees
+        // with the page's own (encoded) canonical.
+        const encodedTag = encodeURIComponent(tag);
         for (let i = 1; i <= totalPage; i++) {
           entries.push({
-            url: `${BASE_URL}/${locale}/${prefix}/tag/${tag}/${i}`,
+            url: `${BASE_URL}/${locale}/${prefix}/tag/${encodedTag}/${i}`,
           });
         }
       }
@@ -67,25 +71,30 @@ async function generatePostSitemap(
   prefix: string,
   service: typeof blogService,
 ): Promise<MetadataRoute.Sitemap> {
-  // Post pages are statically generated for every unique UUID × every
-  // locale, regardless of which language the source post is authored in
-  // (see PostPageFactory.createGenerateStaticParamsFn). Mirror that here
-  // so posts that only exist in en/es are also listed.
+  // Post pages are statically generated for every unique UUID × every locale,
+  // so a post written only in ja is served byte-for-byte identically at
+  // /en/... and /es/.... Those copies canonicalise back to the locale that
+  // owns the content (see PostPageFactory.createGenerateMetadataFn), and a
+  // sitemap is supposed to advertise canonical URLs only — listing the copies
+  // asks crawlers to index pages we ourselves declare non-canonical.
+  //
+  // So emit one entry per language version that actually exists, at the locale
+  // that language belongs to.
   const allPosts = await service.repo.list();
-  const latestByUuid = new Map<string, string>();
+  const lastModifiedByUrl = new Map<string, string>();
   for (const post of allPosts) {
-    const existing = latestByUuid.get(post.meta.uuid);
+    const locale = langToLocale(post.meta.lang);
+    const url = `${BASE_URL}/${locale}/${prefix}/post/${post.meta.uuid}`;
+    const existing = lastModifiedByUrl.get(url);
     if (!existing || existing < post.meta.updated_at) {
-      latestByUuid.set(post.meta.uuid, post.meta.updated_at);
+      lastModifiedByUrl.set(url, post.meta.updated_at);
     }
   }
 
-  return locales.flatMap((locale) =>
-    Array.from(latestByUuid, ([uuid, lastModified]) => ({
-      url: `${BASE_URL}/${locale}/${prefix}/post/${uuid}`,
-      lastModified,
-    })),
-  );
+  return Array.from(lastModifiedByUrl, ([url, lastModified]) => ({
+    url,
+    lastModified,
+  }));
 }
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
@@ -117,12 +126,15 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
 
   // The tag network is exported for every locale via the [locale] layout's
   // generateStaticParams, but is only reachable from the tag index page.
-  const tagNetworkPages: MetadataRoute.Sitemap = locales.map((locale) => ({
-    url: `${BASE_URL}/${locale}/techblog/tag/network`,
-  }));
+  const tagNetworkPages: MetadataRoute.Sitemap = locales.flatMap((locale) =>
+    TAG_NETWORK_PREFIXES.map((prefix) => ({
+      url: `${BASE_URL}/${locale}/${prefix}/tag/network`,
+    })),
+  );
 
+  // The bare origin is not listed: it only redirects to the default locale and
+  // canonicalises to `/${defaultLocale}`, which `localeHomepages` already has.
   return [
-    { url: BASE_URL },
     ...localeHomepages,
     ...staticPages,
     ...tagNetworkPages,

--- a/web/src/components/ArticleJsonLd.tsx
+++ b/web/src/components/ArticleJsonLd.tsx
@@ -19,7 +19,10 @@ export default function ArticleJsonLd({
     "@context": "https://schema.org",
     "@type": "Article",
     headline: meta.title,
-    description: meta.description,
+    // A post whose front-matter description is empty must omit the property
+    // rather than declare an empty one: `"description": ""` is an invalid
+    // value for the field, while an absent property is simply not stated.
+    ...(meta.description ? { description: meta.description } : {}),
     datePublished: meta.created_at,
     dateModified: meta.updated_at,
     inLanguage: meta.lang,

--- a/web/src/features/articles/components/Pager.test.tsx
+++ b/web/src/features/articles/components/Pager.test.tsx
@@ -25,11 +25,30 @@ function uuid(n: number): string {
 }
 
 describe("Pager", () => {
+  it("renders the heading as the page's h1", () => {
+    const { container } = render(
+      <Pager
+        prefix="ja/techblog"
+        heading="techblog 記事一覧"
+        pageInformation={{
+          pagePostMetas: [],
+          curPage: 1,
+          pages: [1],
+        }}
+        pageLinkGenerator={linkGen}
+      />,
+    );
+    const h1s = container.querySelectorAll("h1");
+    expect(h1s).toHaveLength(1);
+    expect(h1s[0].textContent).toBe("techblog 記事一覧");
+  });
+
   it("renders one PostCard per page post", () => {
     const posts = [meta(uuid(1), "first"), meta(uuid(2), "second")];
     render(
       <Pager
         prefix="ja/techblog"
+        heading="techblog 記事一覧"
         pageInformation={{
           pagePostMetas: posts,
           curPage: 1,
@@ -46,6 +65,7 @@ describe("Pager", () => {
     render(
       <Pager
         prefix="ja/techblog"
+        heading="techblog 記事一覧"
         pageInformation={{
           pagePostMetas: [],
           curPage: 3,
@@ -65,6 +85,7 @@ describe("Pager", () => {
     render(
       <Pager
         prefix="ja/techblog"
+        heading="techblog 記事一覧"
         pageInformation={{
           pagePostMetas: [],
           curPage: 1,
@@ -83,6 +104,7 @@ describe("Pager", () => {
     render(
       <Pager
         prefix="ja/techblog"
+        heading="techblog 記事一覧"
         pageInformation={{
           pagePostMetas: [],
           curPage: 10,
@@ -102,6 +124,7 @@ describe("Pager", () => {
     render(
       <Pager
         prefix="ja/techblog"
+        heading="techblog 記事一覧"
         pageInformation={{
           pagePostMetas: [],
           curPage: 12,
@@ -121,6 +144,7 @@ describe("Pager", () => {
     const { container, unmount } = render(
       <Pager
         prefix="ja/techblog"
+        heading="techblog 記事一覧"
         pageInformation={{
           pagePostMetas: [],
           curPage: 1,
@@ -138,6 +162,7 @@ describe("Pager", () => {
     render(
       <Pager
         prefix="ja/techblog"
+        heading="techblog 記事一覧"
         pageInformation={{
           pagePostMetas: [],
           curPage: 2,
@@ -155,6 +180,7 @@ describe("Pager", () => {
     render(
       <Pager
         prefix="ja/techblog"
+        heading="techblog 記事一覧"
         pageInformation={{
           pagePostMetas: [],
           curPage: 3,

--- a/web/src/features/articles/components/Pager.tsx
+++ b/web/src/features/articles/components/Pager.tsx
@@ -132,6 +132,11 @@ function Pagination({ curPage, pages, pageLinkGenerator }: PaginationProps) {
 
 interface PagerProps {
   prefix: string;
+  /**
+   * Page heading. Rendered as the `<h1>`: the cards below are `<h2>`, so
+   * without it a listing page has no top-level heading at all.
+   */
+  heading: string;
   pageInformation: PageInformation;
   pageLinkGenerator: (page: number) => Route;
   className?: string;
@@ -139,6 +144,7 @@ interface PagerProps {
 
 export default function Pager({
   prefix,
+  heading,
   pageInformation,
   pageLinkGenerator,
   className,
@@ -147,6 +153,18 @@ export default function Pager({
 
   return (
     <div className={className}>
+      <h1
+        className={css({
+          fontSize: { base: "xl", md: "2xl" },
+          fontWeight: "bold",
+          color: "text.primary",
+          px: 4,
+          pt: 5,
+          pb: 2,
+        })}
+      >
+        {heading}
+      </h1>
       {pagePostMetas.map((meta, i) => (
         <PostCard prefix={prefix} meta={meta} key={i} />
       ))}


### PR DESCRIPTION
静的エクスポート後の HTML 496 ページを実際に走査して SEO 監査を行い、クローラが受け取る内容の不具合を修正しました。

## 監査方法

`pnpm dump` → `pnpm web-build:web` でビルドし、`web/out` 配下の全 HTML と `sitemap.xml` を突き合わせて検査しました（title / description / canonical / hreflang / h1 / JSON-LD / sitemap と canonical の整合性 / 内部リンクの到達性）。

## 修正内容

### 1. `/`（apex）が Next.js のエラーシェルを返していた（最重要）

静的エクスポートでは `redirect()` を処理するサーバがないため、`web/out/index.html` は `<html id="__next_error__">` のエラーシェルとして出力されていました。title も description も canonical も本文も無く、React の hydration 後にしか `/ja` へ移動しません。被リンクが最も集まるオリジンがこの状態でした。

`app/page.tsx` を実体のあるドキュメントに変更し、default locale への canonical、全 locale の hreflang、遅延 0 の meta refresh とプレーンなリンクを出力するようにしました。

**修正前:**
```html
<!DOCTYPE html><html id="__next_error__"><head><meta charSet="utf-8"/>...
```
**修正後:**
```html
<meta http-equiv="refresh" content="0; url=/ja"/><title>illumination-k.dev</title>
<meta name="description" content="Software Engineer / Bioinformatics"/>
<link rel="canonical" href="https://illumination-k.dev/ja"/>
<link rel="alternate" hrefLang="ja" href="https://illumination-k.dev/ja"/>...
```

### 2. sitemap が自ら非 canonical と宣言した URL を 112 件掲載していた

未翻訳記事も全 locale に静的生成されるため、ja のみの記事は `/en/...` `/es/...` にも同一内容で出力され、それらの canonical は ja を指します。sitemap は canonical URL のみを載せるべきなので、記事は「実在する言語版ごとに、その言語の locale で 1 件」に変更しました。`/ja` へ canonical する裸のオリジンも同じ理由で除外しています。

sitemap のエントリ数は 491 → 384、非 canonical エントリは 112 → 0 になりました。

### 3. 空白を含むタグが `<loc>` に未エンコードで出力されていた

`chrome extension` / `nature genetics` が `<loc>` にそのまま書かれ、URL として不正なうえ、ページ側の canonical（`chrome%20extension`）とも食い違っていました。`encodeURIComponent` を通すようにしました。

### 4. paperstream のタグ一覧が 404 にリンクしていた

`TagTopPageFactory` は両 prefix で `{prefix}/tag/network` へリンクしますが、ルートは techblog にしかありませんでした。タグネットワークページを `tagNetworkFactory` として共通化し、`paperstream/tag/network` を追加しました（辞書の `tagNetwork(prefix)` は元から prefix を受け取る設計です）。sitemap も両 prefix を出力します。

### 5. disclaimer / privacy-policy の title でサイト名が二重になっていた

layout の title template が ` | illumination-k.dev` を付与するのに、ページ側でも付けていたため 6 ページで重複していました。

`免責事項 | illumination-k.dev | illumination-k.dev` → `免責事項 | illumination-k.dev`

### 6. 一覧系 194 ページに `<h1>` が存在しなかった

記事一覧・タグ一覧・タグ別一覧には見出しが一切なく、`PostCard` の `<h2>` が最上位でした。`Pager` に必須の `heading` prop を追加し、ページタイトルと同じローカライズ済み文字列を `<h1>` として描画します。

### 7. JSON-LD の空 description と、description 未設定の記事

`ArticleJsonLd` が `"description": ""` を出力していたため、空の場合はプロパティごと省略するようにしました。あわせて description が空だった paperStream の記事 1 件に description を追加しています（本来は Notion 側の `AiDesc` 由来なので、再エクスポートで戻る点は注意が必要です）。

### 8. `post-utils lint <src>` が常に "Invalid usage" で失敗していた

yargs の command 文字列に `<src>` が無く positional が束縛されないため `demandOption` に落ちており、SEO メタ長チェックが一度も実行できない状態でした。`migration` も同じ不具合だったので合わせて修正しています。

## 検証

- `pnpm lint` / `pnpm test`（122 web tests を含む全 6 パッケージ）green
- 再ビルド後の `web/out` 再走査:
  - エラーシェル 1 → 0、title 欠落 1 → 0、title 重複 6 → 0
  - `<h1>` 欠落 197 → 4（`/` のリダイレクト用スタブと noindex の `/search` 3 件のみ）
  - description 欠落 6 → 2（`404.html` と `_not-found.html` のみ）
  - sitemap: 非 canonical エントリ 0、未生成ページの掲載 0、空白を含む `<loc>` 0

## 残した項目

- `/{locale}/search` は canonical 無し・`noindex, follow` のまま（Pagefind によるクライアント描画のため意図通り）
- `pnpm cli lint` は動くようになりましたが既存記事に 119 件（techblog）/ 7 件（paperStream）の title・description 長エラーがあるため、CI への組み込みは行っていません

---
_Generated by [Claude Code](https://claude.ai/code/session_01JN85TcrJmRpPmkA3aux3D6)_