### PR TITLE
Fix dependency audit failures for high severity advisories

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -22,7 +22,6 @@
     "common": "workspace:^",
     "feed": "^4.2.2",
     "front-matter": "^4.0.2",
-    "image-size": "^1.2.1",
     "ipynb2md": "workspace:^",
     "md-plugins": "workspace:^",
     "mdast-util-to-string": "^4.0.0",

--- a/cli/src/optimizeImage.ts
+++ b/cli/src/optimizeImage.ts
@@ -5,8 +5,6 @@ import util from "node:util";
 
 import type { Image, Root } from "mdast";
 
-import sizeOf from "image-size";
-
 import { cacheGet, cacheSet, fetchWithRetry, getCacheKey } from "md-plugins";
 import sharp from "sharp";
 import { file } from "tmp-promise";
@@ -75,7 +73,14 @@ type Option = {
 
 const writeAsync = util.promisify(fs.writeFile);
 const copyAsync = util.promisify(fs.copyFile);
-const sizeOfAsync = util.promisify(sizeOf);
+
+// image-sizeはICNS/JXL/HEIFパーサに未修正のDoS脆弱性
+// (GHSA-w3rx-r6r6-pgpr / GHSA-5p2g-fcmc-qvqq)があるため、
+// すでに依存しているsharpのmetadataでサイズを取得する
+const sizeOfAsync = async (imagePath: string): Promise<Size> => {
+  const { width, height } = await sharp(imagePath).metadata();
+  return { width, height };
+};
 
 const optimizeImage = (option: Option) => {
   const postDirPath = path.resolve(path.dirname(option.postPath.toString()));

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,10 @@ settings:
 overrides:
   postcss@<8.5.18: ^8.5.25
   sharp@<0.35.0: ^0.35.3
+  nanoid@<3.3.17: ^3.3.17
+  js-yaml@<3.15.1: ^3.15.1
+  js-yaml@>=4.0.0 <4.3.1: ^4.3.1
+  undici@>=7.0.0 <7.29.0: ^7.29.0
 
 importers:
 
@@ -75,9 +79,6 @@ importers:
       front-matter:
         specifier: ^4.0.2
         version: 4.0.2
-      image-size:
-        specifier: ^1.2.1
-        version: 1.2.1
       ipynb2md:
         specifier: workspace:^
         version: link:../packages/ipynb2md
@@ -4705,11 +4706,6 @@ packages:
     resolution: {integrity: sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==}
     engines: {node: '>= 4'}
 
-  image-size@1.2.1:
-    resolution: {integrity: sha512-rH+46sQJ2dlwfjfhCyNx5thzrv+dtmBIhPHk0zgRUukHzZ/kRueTJXoYYsclBaKcSMBWuGbOFXtioLpzTb5euw==}
-    engines: {node: '>=16.x'}
-    hasBin: true
-
   import-fresh@3.3.1:
     resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
     engines: {node: '>=6'}
@@ -5019,12 +5015,12 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@3.15.0:
-    resolution: {integrity: sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==}
+  js-yaml@3.15.1:
+    resolution: {integrity: sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==}
     hasBin: true
 
-  js-yaml@4.3.0:
-    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
+  js-yaml@4.3.1:
+    resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
     hasBin: true
 
   jsdom@29.1.1:
@@ -5745,8 +5741,8 @@ packages:
   mz@2.7.0:
     resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
 
-  nanoid@3.3.16:
-    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -6259,9 +6255,6 @@ packages:
 
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
-
-  queue@6.0.2:
-    resolution: {integrity: sha512-iHZWu+q3IdFZFX36ro/lKBkSvfkztY5Y7HMiPlOUjhupPcG2JMfst2KKEpu5XndviX/3UhFbRngUPNKtgvtZiA==}
 
   quick-format-unescaped@4.0.4:
     resolution: {integrity: sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==}
@@ -7296,10 +7289,6 @@ packages:
 
   undici-types@7.18.2:
     resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
-
-  undici@7.28.0:
-    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
-    engines: {node: '>=20.18.1'}
 
   undici@7.29.0:
     resolution: {integrity: sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==}
@@ -8402,7 +8391,7 @@ snapshots:
       globals: 14.0.0
       ignore: 5.3.2
       import-fresh: 3.3.1
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       minimatch: 3.1.5
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
@@ -9611,7 +9600,7 @@ snapshots:
       '@textlint/types': 15.7.1
       chalk: 4.1.2
       debug: 4.4.3
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       lodash: 4.18.1
       pluralize: 2.0.0
       string-width: 4.2.3
@@ -11910,7 +11899,7 @@ snapshots:
 
   front-matter@4.0.2:
     dependencies:
-      js-yaml: 3.15.0
+      js-yaml: 3.15.1
 
   fs-extra@11.3.2:
     dependencies:
@@ -12295,10 +12284,6 @@ snapshots:
 
   ignore@7.0.6: {}
 
-  image-size@1.2.1:
-    dependencies:
-      queue: 6.0.2
-
   import-fresh@3.3.1:
     dependencies:
       parent-module: 1.0.1
@@ -12572,12 +12557,12 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@3.15.0:
+  js-yaml@3.15.1:
     dependencies:
       argparse: 1.0.10
       esprima: 4.0.1
 
-  js-yaml@4.3.0:
+  js-yaml@4.3.1:
     dependencies:
       argparse: 2.0.1
 
@@ -13556,7 +13541,7 @@ snapshots:
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       sharp: 0.35.2
-      undici: 7.28.0
+      undici: 7.29.0
       workerd: 1.20260730.1
       ws: 8.21.0
       youch: 4.1.0-beta.10
@@ -13626,7 +13611,7 @@ snapshots:
       object-assign: 4.1.1
       thenify-all: 1.6.0
 
-  nanoid@3.3.16: {}
+  nanoid@3.3.18: {}
 
   napi-postinstall@0.3.4: {}
 
@@ -14061,7 +14046,7 @@ snapshots:
 
   postcss@8.5.25:
     dependencies:
-      nanoid: 3.3.16
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -14085,7 +14070,7 @@ snapshots:
     dependencies:
       commandpost: 1.4.0
       diff: 4.0.4
-      js-yaml: 3.15.0
+      js-yaml: 3.15.1
 
   process-warning@5.1.0: {}
 
@@ -14133,10 +14118,6 @@ snapshots:
       side-channel: 1.1.1
 
   queue-microtask@1.2.3: {}
-
-  queue@6.0.2:
-    dependencies:
-      inherits: 2.0.4
 
   quick-format-unescaped@4.0.4: {}
 
@@ -14214,7 +14195,7 @@ snapshots:
   rc-config-loader@4.1.4:
     dependencies:
       debug: 4.4.3
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       json5: 2.2.3
       require-from-string: 2.0.2
     transitivePeerDependencies:
@@ -15703,8 +15684,6 @@ snapshots:
   underscore@1.13.8: {}
 
   undici-types@7.18.2: {}
-
-  undici@7.28.0: {}
 
   undici@7.29.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,6 +7,14 @@ packages:
 overrides:
   "postcss@<8.5.18": "^8.5.25"
   "sharp@<0.35.0": "^0.35.3"
+  # GHSA-2v37-7h3g-55p8 (nanoid: infinite loop with size 0)
+  "nanoid@<3.3.17": "^3.3.17"
+  # GHSA-5p4m-2wfm-xmqj (js-yaml: quadratic CPU consumption in !!omap)
+  # 3.x と 4.x はAPIが非互換なのでメジャーごとに指定する
+  "js-yaml@<3.15.1": "^3.15.1"
+  "js-yaml@>=4.0.0 <4.3.1": "^4.3.1"
+  # GHSA-4cwx-7wf7-3272 (undici: cross-user information disclosure)
+  "undici@>=7.0.0 <7.29.0": "^7.29.0"
 
 auditConfig:
   ignoreCves:


### PR DESCRIPTION
## 概要

Dependency Audit ワークフロー（`pnpm-audit-prod` / `pnpm-audit-dev`）が high 検出で落ち続けていたので修正した。

## 検出されていた high advisory

| Package | Path | Advisory | 対応 |
| --- | --- | --- | --- |
| nanoid `<3.3.17` | `web>next>postcss>nanoid` | [GHSA-2v37-7h3g-55p8](https://github.com/advisories/GHSA-2v37-7h3g-55p8) | override `^3.3.17` |
| js-yaml `>=3.0.0 <3.15.1` | `cli>front-matter>js-yaml`, `prh>js-yaml` | [GHSA-5p4m-2wfm-xmqj](https://github.com/advisories/GHSA-5p4m-2wfm-xmqj) | override `^3.15.1` |
| js-yaml `>=4.0.0 <4.3.1` | `textlint>@textlint/linter-formatter>js-yaml` | [GHSA-5p4m-2wfm-xmqj](https://github.com/advisories/GHSA-5p4m-2wfm-xmqj) | override `^4.3.1` |
| undici `>=7.0.0 <7.29.0` | `web>wrangler>miniflare>undici` | [GHSA-4cwx-7wf7-3272](https://github.com/advisories/GHSA-4cwx-7wf7-3272) | override `^7.29.0` |
| image-size `<=2.0.2` | `cli>image-size` | [GHSA-w3rx-r6r6-pgpr](https://github.com/advisories/GHSA-w3rx-r6r6-pgpr) / [GHSA-5p2g-fcmc-qvqq](https://github.com/advisories/GHSA-5p2g-fcmc-qvqq) | 依存を削除 |

## 変更内容

### `pnpm-workspace.yaml`

nanoid / js-yaml / undici を `overrides` で修正版に固定した。js-yaml は 3.x と 4.x で API が非互換なので、片方に寄せずメジャーごとにセレクタを分けている。

### `cli` から `image-size` を削除

image-size は最新の 2.0.2 も脆弱で修正版が存在しない（advisory の Patched versions が `<0.0.0`）ため、override では解決できなかった。

使用箇所は `cli/src/optimizeImage.ts` の 1 箇所だけで、sharp が AVIF に変換した後の出力ファイルの幅・高さを読むためだけに使っていた。sharp はすでに依存に入っているので、`sharp(path).metadata()` に置き換えて依存ごと外した。呼び出し側のシグネチャ（`Promise<{width?, height?}>`）は変えていないので、リトライループや `hProperties` の組み立ては従来どおり。

## 確認したこと

- `pnpm audit --prod --audit-level=high` → high 0 件（`1 low | 5 moderate`）
- `pnpm audit --audit-level=high` → high 0 件（`3 low | 9 moderate`）
- `pnpm lint` / `pnpm test` ともにパス
- sharp の `metadata()` が AVIF 出力の寸法を正しく返すことを実際に確認（321x123 の AVIF を生成して読み戻し）

残っている moderate / low は `--audit-level=high` の閾値以下なので今回は対象外。


---
_Generated by [Claude Code](https://claude.ai/code/session_01WLsK5bzctRhd6k1Xb2enkB)_